### PR TITLE
[FEAT] 공고 등록, 임시저장 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
+	//AWS S3
+	implementation 'software.amazon.awssdk:s3:2.27.12'
+
 	// Apache Commons Validator
 	implementation 'commons-validator:commons-validator:1.9.0'
 

--- a/src/main/java/com/core/foreign/api/aws/service/S3Service.java
+++ b/src/main/java/com/core/foreign/api/aws/service/S3Service.java
@@ -1,0 +1,71 @@
+package com.core.foreign.api.aws.service;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucketName}")
+    private String bucketName; // S3 버킷 이름
+
+    @Value("${cloud.aws.s3.url}")
+    private String s3Domain; // S3 도메인
+
+    // 채용 공고 포스터 이미지 업로드 메서드
+    public String uploadRecruitPostImage(MultipartFile file) throws IOException {
+        String dir = "recruit-post-image";
+        // 현재 날짜/시간
+        String currentDateTime = new SimpleDateFormat("yyyy-MM-dd_HH:mm:ss").format(new Date());
+        // 확장자 추출
+        String originalFilename = file.getOriginalFilename();
+        String extension = "";
+        if (originalFilename != null && originalFilename.contains(".")) {
+            extension = originalFilename.substring(originalFilename.lastIndexOf("."));
+        }
+        // 파일명 예시: post_2025-01-26_19:32:12.jpg
+        String fileName = "post_" + currentDateTime + extension;
+        // 난수 문자열
+        String randomString = RandomStringUtils.randomAlphanumeric(16);
+        // 최종 S3 경로
+        String fileKey = dir + "/" + randomString + "/" + fileName;
+
+        // 업로드
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(fileKey)
+                .acl("public-read")
+                .build();
+        s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+
+        // 업로드 후 S3 도메인 + 경로 형태의 URL 반환
+        return s3Domain + "/" + fileKey;
+    }
+
+    // 파일 삭제 메서드
+    public void deleteFile(String imageUrl) {
+        if (imageUrl != null && imageUrl.startsWith(s3Domain)) {
+            // S3 도메인을 제외한 key 추출
+            String fileKey = imageUrl.replace(s3Domain + "/", "");
+            DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(fileKey)
+                    .build();
+            s3Client.deleteObject(deleteObjectRequest);
+        }
+    }
+}

--- a/src/main/java/com/core/foreign/api/business_field/entity/BusinessFieldEntity.java
+++ b/src/main/java/com/core/foreign/api/business_field/entity/BusinessFieldEntity.java
@@ -1,6 +1,5 @@
 package com.core.foreign.api.business_field.entity;
 
-
 import com.core.foreign.api.business_field.BusinessField;
 import com.core.foreign.api.business_field.BusinessFieldTarget;
 import jakarta.persistence.*;
@@ -21,7 +20,6 @@ public class BusinessFieldEntity {
 
     @Enumerated(STRING)
     private BusinessField businessField;
-
 
     @Enumerated(STRING)
     @Column(name="target")

--- a/src/main/java/com/core/foreign/api/recruit/controller/RecruitController.java
+++ b/src/main/java/com/core/foreign/api/recruit/controller/RecruitController.java
@@ -1,0 +1,296 @@
+package com.core.foreign.api.recruit.controller;
+
+import com.core.foreign.api.recruit.dto.RecruitResponseDTO;
+import com.core.foreign.api.recruit.dto.RecruitRequestDTO;
+import com.core.foreign.api.recruit.service.RecruitService;
+import com.core.foreign.common.SecurityMember;
+import com.core.foreign.common.response.ApiResponse;
+import com.core.foreign.common.response.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Tag(name = "Recruit", description = "공고 관련 API 입니다.<br>" +
+        "<p>" +
+        "[사용자 임시저장 데이터조회 API + 작성 가능 공고 조회 API(구현 예정) + 회사 정보 조회 API(구현 예정) -> 만약 임시저장 데이터 있다면 -> 해당 공고 퍼블리싱 API / 임시 저장 데이터가 없다면 -> 공고 등록 API")
+@RestController
+@RequestMapping("/api/v1/recruit")
+@RequiredArgsConstructor
+public class RecruitController {
+
+    private final RecruitService recruitService;
+
+    @Operation(summary = "일반 공고 등록 API",
+            description = "일반 공고를 등록합니다.<br>" +
+                    "<p>" +
+                    "title : 공고 제목<br>" +
+                    "recruitStartDate : 모집 시작일<br>" +
+                    "recruitEndDate : 모집 종료일<br>" +
+                    "recruitCount : 모집 인원<br>" +
+                    "gender : 성별 (무관일시 null)<br>" +
+                    "education : 학력 조건<br>" +
+                    "otherConditions : 기타 조건<br>" +
+                    "preferredConditions : 우대 조건 리스트<br>" +
+                    "workDuration : 근무 기간<br>" +
+                    "workTime : 근무 시간(직접 선택시 '시작시간~종료시간'<br>" +
+                    "workDays : 근무 요일<br>" +
+                    "workDaysOther : 근무 요일 기타 사항(없다면 null)<br>" +
+                    "salary : 급여 정보<br>" +
+                    "salaryType : 급여 형태 (월급, 시급 등)<br>" +
+                    "businessFields : 업직종 리스트<br>" +
+                    "applicationMethods : 지원 방법<br>" +
+                    "latitude : 위도<br>" +
+                    "longitude : 경도<br>" +
+                    "zipcode : 우편 번호<br>" +
+                    "address1 : 주소<br>" +
+                    "address2 : 상세 주소<br>")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "공고 등록 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+    })
+    @PostMapping(value = "/general", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<Void>> createGeneralRecruit(
+            @AuthenticationPrincipal SecurityMember securityMember,
+            @RequestPart("request") RecruitRequestDTO.GeneralRecruitRequest recruitRequest,
+            @RequestPart(value = "posterImage", required = false) MultipartFile posterImage
+    ) {
+        recruitService.createGeneralRecruit(securityMember.getId(), recruitRequest, posterImage);
+        return ApiResponse.success_only(SuccessStatus.CREATE_RECRUIT_ARTICLE_SUCCESS);
+    }
+
+    @Operation(summary = "프리미엄 공고 등록 API",
+            description = "프리미엄 공고를 등록합니다.<br>" +
+                    "<p>" +
+                    "title : 공고 제목<br>" +
+                    "recruitStartDate : 모집 시작일<br>" +
+                    "recruitEndDate : 모집 종료일<br>" +
+                    "recruitCount : 모집 인원<br>" +
+                    "gender : 성별 (무관일시 null)<br>" +
+                    "education : 학력 조건<br>" +
+                    "otherConditions : 기타 조건<br>" +
+                    "preferredConditions : 우대 조건 리스트<br>" +
+                    "workDuration : 근무 기간<br>" +
+                    "workTime : 근무 시간(직접 선택시 '시작시간~종료시간'<br>" +
+                    "workDays : 근무 요일<br>" +
+                    "workDaysOther : 근무 요일 기타 사항(없다면 null)<br>" +
+                    "salary : 급여 정보<br>" +
+                    "salaryType : 급여 형태 (월급, 시급 등)<br>" +
+                    "businessFields : 업직종 리스트<br>" +
+                    "applicationMethods : 지원 방법<br>" +
+                    "latitude : 위도<br>" +
+                    "longitude : 경도<br>" +
+                    "zipcode : 우편 번호<br>" +
+                    "address1 : 주소<br>" +
+                    "address2 : 상세 주소<br>" +
+                    "<p>" +
+                    "Portfolios<br>" +
+                    "title : 질문 제목<br>" +
+                    "type : 질문 유형(LONG_TEXT : 장문형 / SHORT_TEXT : 단답형 / FILE_UPLOAD : 파일 업로드)<br>" +
+                    "required : 필수 질문<br>" +
+                    "maxFileCount : 최대 업로드 가능 갯수(FILE_UPLOAD 일때만, 다른 유형일 경우 null)<br>" +
+                    "maxFileSize : 최대 업로드 가능 파일 사이즈(FILE_UPLOAD 일때만, 다른 유형일 경우 null)<br>")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "공고 등록 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+    })
+    @PostMapping(value = "/premium", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<Void>> createPremiumRecruit(
+            @AuthenticationPrincipal SecurityMember securityMember,
+            @RequestPart("request") RecruitRequestDTO.PremiumRecruitRequest recruitRequest,
+            @RequestPart(value = "posterImage", required = false) MultipartFile posterImage
+    ) {
+        recruitService.createPremiumRecruit(securityMember.getId(), recruitRequest, posterImage);
+        return ApiResponse.success_only(SuccessStatus.CREATE_RECRUIT_ARTICLE_SUCCESS);
+    }
+
+    @Operation(summary = "일반 공고 임시저장 API",
+            description = "일반 공고를 임시저장 합니다.<br>" +
+                    "<p>" +
+                    "title : 공고 제목<br>" +
+                    "recruitStartDate : 모집 시작일<br>" +
+                    "recruitEndDate : 모집 종료일<br>" +
+                    "recruitCount : 모집 인원<br>" +
+                    "gender : 성별 (무관일시 null)<br>" +
+                    "education : 학력 조건<br>" +
+                    "otherConditions : 기타 조건<br>" +
+                    "preferredConditions : 우대 조건 리스트<br>" +
+                    "workDuration : 근무 기간<br>" +
+                    "workTime : 근무 시간(직접 선택시 '시작시간~종료시간'<br>" +
+                    "workDays : 근무 요일<br>" +
+                    "workDaysOther : 근무 요일 기타 사항(없다면 null)<br>" +
+                    "salary : 급여 정보<br>" +
+                    "salaryType : 급여 형태 (월급, 시급 등)<br>" +
+                    "businessFields : 업직종 리스트<br>" +
+                    "applicationMethods : 지원 방법<br>" +
+                    "latitude : 위도<br>" +
+                    "longitude : 경도<br>" +
+                    "zipcode : 우편 번호<br>" +
+                    "address1 : 주소<br>" +
+                    "address2 : 상세 주소<br>")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "공고 임시 저장 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+    })
+    @PostMapping(value = "/general/draft", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<Void>> saveGeneralRecruitDraft(
+            @AuthenticationPrincipal SecurityMember securityMember,
+            @RequestPart("request") RecruitRequestDTO.GeneralRecruitRequest recruitRequest,
+            @RequestPart(value = "posterImage", required = false) MultipartFile posterImage
+    ) {
+        recruitService.saveGeneralRecruitDraft(securityMember.getId(), recruitRequest, posterImage);
+        return ApiResponse.success_only(SuccessStatus.CREATE_DRAFT_RECRUIT_ARTICLE_SUCCESS);
+    }
+
+    @Operation(summary = "프리미엄 공고 임시저장 API",
+            description = "프리미엄 공고를 임시저장 합니다.<br>" +
+                    "<p>" +
+                    "title : 공고 제목<br>" +
+                    "recruitStartDate : 모집 시작일<br>" +
+                    "recruitEndDate : 모집 종료일<br>" +
+                    "recruitCount : 모집 인원<br>" +
+                    "gender : 성별 (무관일시 null)<br>" +
+                    "education : 학력 조건<br>" +
+                    "otherConditions : 기타 조건<br>" +
+                    "preferredConditions : 우대 조건 리스트<br>" +
+                    "workDuration : 근무 기간<br>" +
+                    "workTime : 근무 시간(직접 선택시 '시작시간~종료시간'<br>" +
+                    "workDays : 근무 요일<br>" +
+                    "workDaysOther : 근무 요일 기타 사항(없다면 null)<br>" +
+                    "salary : 급여 정보<br>" +
+                    "salaryType : 급여 형태 (월급, 시급 등)<br>" +
+                    "businessFields : 업직종 리스트<br>" +
+                    "applicationMethods : 지원 방법<br>" +
+                    "latitude : 위도<br>" +
+                    "longitude : 경도<br>" +
+                    "zipcode : 우편 번호<br>" +
+                    "address1 : 주소<br>" +
+                    "address2 : 상세 주소<br>" +
+                    "<p>" +
+                    "Portfolios<br>" +
+                    "title : 질문 제목<br>" +
+                    "type : 질문 유형(LONG_TEXT : 장문형 / SHORT_TEXT : 단답형 / FILE_UPLOAD : 파일 업로드)<br>" +
+                    "required : 필수 질문<br>" +
+                    "maxFileCount : 최대 업로드 가능 갯수(FILE_UPLOAD 일때만, 다른 유형일 경우 null)<br>" +
+                    "maxFileSize : 최대 업로드 가능 파일 사이즈(FILE_UPLOAD 일때만, 다른 유형일 경우 null)<br>")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "공고 임시 저장 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+    })
+    @PostMapping(value = "/premium/draft", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<Void>> savePremiumRecruitDraft(
+            @AuthenticationPrincipal SecurityMember securityMember,
+            @RequestPart("request") RecruitRequestDTO.PremiumRecruitRequest recruitRequest,
+            @RequestPart(value = "posterImage", required = false) MultipartFile posterImage
+    ) {
+        recruitService.savePremiumRecruitDraft(securityMember.getId(), recruitRequest, posterImage);
+        return ApiResponse.success_only(SuccessStatus.CREATE_DRAFT_RECRUIT_ARTICLE_SUCCESS);
+    }
+
+    @Operation(summary = "일반 공고 퍼블리싱 API",
+            description = "임시 저장한 일반 공고를 최종 퍼블리싱 합니다.<br>" +
+                    "<p>" +
+                    "title : 공고 제목<br>" +
+                    "recruitStartDate : 모집 시작일<br>" +
+                    "recruitEndDate : 모집 종료일<br>" +
+                    "recruitCount : 모집 인원<br>" +
+                    "gender : 성별 (무관일시 null)<br>" +
+                    "education : 학력 조건<br>" +
+                    "otherConditions : 기타 조건<br>" +
+                    "preferredConditions : 우대 조건 리스트<br>" +
+                    "workDuration : 근무 기간<br>" +
+                    "workTime : 근무 시간(직접 선택시 '시작시간~종료시간'<br>" +
+                    "workDays : 근무 요일<br>" +
+                    "workDaysOther : 근무 요일 기타 사항(없다면 null)<br>" +
+                    "salary : 급여 정보<br>" +
+                    "salaryType : 급여 형태 (월급, 시급 등)<br>" +
+                    "businessFields : 업직종 리스트<br>" +
+                    "applicationMethods : 지원 방법<br>" +
+                    "latitude : 위도<br>" +
+                    "longitude : 경도<br>" +
+                    "zipcode : 우편 번호<br>" +
+                    "address1 : 주소<br>" +
+                    "address2 : 상세 주소<br>")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "공고 등록 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+    })
+    @PutMapping(value = "/general/{recruitId}/publish", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<Void>> publishGeneralRecruit(
+            @PathVariable Long recruitId,
+            @RequestPart("request") RecruitRequestDTO.GeneralRecruitRequest recruitRequest,
+            @RequestPart(value = "posterImage", required = false) MultipartFile posterImage
+    ) {
+        recruitService.publishGeneralRecruit(recruitId, recruitRequest, posterImage);
+        return ApiResponse.success_only(SuccessStatus.CREATE_RECRUIT_ARTICLE_SUCCESS);
+    }
+
+    @Operation(summary = "프리미엄 공고 퍼블리싱 API",
+            description = "임시 저장한 프리미엄 공고를 최종 퍼블리싱 합니다.<br>" +
+                    "<p>" +
+                    "title : 공고 제목<br>" +
+                    "recruitStartDate : 모집 시작일<br>" +
+                    "recruitEndDate : 모집 종료일<br>" +
+                    "recruitCount : 모집 인원<br>" +
+                    "gender : 성별 (무관일시 null)<br>" +
+                    "education : 학력 조건<br>" +
+                    "otherConditions : 기타 조건<br>" +
+                    "preferredConditions : 우대 조건 리스트<br>" +
+                    "workDuration : 근무 기간<br>" +
+                    "workTime : 근무 시간(직접 선택시 '시작시간~종료시간'<br>" +
+                    "workDays : 근무 요일<br>" +
+                    "workDaysOther : 근무 요일 기타 사항(없다면 null)<br>" +
+                    "salary : 급여 정보<br>" +
+                    "salaryType : 급여 형태 (월급, 시급 등)<br>" +
+                    "businessFields : 업직종 리스트<br>" +
+                    "applicationMethods : 지원 방법<br>" +
+                    "latitude : 위도<br>" +
+                    "longitude : 경도<br>" +
+                    "zipcode : 우편 번호<br>" +
+                    "address1 : 주소<br>" +
+                    "address2 : 상세 주소<br>" +
+                    "<p>" +
+                    "Portfolios<br>" +
+                    "title : 질문 제목<br>" +
+                    "type : 질문 유형(LONG_TEXT : 장문형 / SHORT_TEXT : 단답형 / FILE_UPLOAD : 파일 업로드)<br>" +
+                    "required : 필수 질문<br>" +
+                    "maxFileCount : 최대 업로드 가능 갯수(FILE_UPLOAD 일때만, 다른 유형일 경우 null)<br>" +
+                    "maxFileSize : 최대 업로드 가능 파일 사이즈(FILE_UPLOAD 일때만, 다른 유형일 경우 null)<br>")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "공고 등록 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+    })
+    @PutMapping(value = "/premium/{recruitId}/publish", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<Void>> publishPremiumRecruit(
+            @PathVariable Long recruitId,
+            @RequestPart("request") RecruitRequestDTO.PremiumRecruitRequest recruitRequest,
+            @RequestPart(value = "posterImage", required = false) MultipartFile posterImage
+    ) {
+        recruitService.publishPremiumRecruit(recruitId, recruitRequest, posterImage);
+        return ApiResponse.success_only(SuccessStatus.CREATE_RECRUIT_ARTICLE_SUCCESS);
+    }
+
+    @Operation(summary = "사용자 임시저장 데이터 조회 API",
+            description = "임시 저장한 데이터가 있는지 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "임시 저장된 공고 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+    })
+    @GetMapping("/drafts")
+    public ResponseEntity<ApiResponse<List<RecruitResponseDTO>>> getDrafts(
+            @AuthenticationPrincipal SecurityMember securityMember
+    ) {
+        List<RecruitResponseDTO> drafts = recruitService.getDrafts(securityMember.getId());
+        if (drafts.isEmpty()) {
+            return ApiResponse.success(SuccessStatus.SEND_NO_DRAFT_SAVE_SUCCESS, List.of());
+        }
+        return ApiResponse.success(SuccessStatus.SEND_DRAFT_SAVE_SUCCESS, drafts);
+    }
+}

--- a/src/main/java/com/core/foreign/api/recruit/dto/RecruitRequestDTO.java
+++ b/src/main/java/com/core/foreign/api/recruit/dto/RecruitRequestDTO.java
@@ -1,0 +1,72 @@
+package com.core.foreign.api.recruit.dto;
+
+import com.core.foreign.api.member.entity.Address;
+import com.core.foreign.api.recruit.entity.PortfolioType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class RecruitRequestDTO {
+
+    @Getter
+    @Builder
+    public static class GeneralRecruitRequest {
+        private String title;
+        private Address address;
+        private List<String> businessFields;
+        private Double latitude;
+        private Double longitude;
+        private LocalDate recruitStartDate;
+        private LocalDate recruitEndDate;
+        private Integer recruitCount;
+        private String gender;
+        private String education;
+        private String otherConditions;
+        private List<String> preferredConditions;
+        private String workDuration;
+        private String workTime;
+        private String workDays;
+        private String workDaysOther;
+        private String salary;
+        private String salaryType;
+        private List<String> applicationMethods;
+    }
+
+    @Getter
+    @Builder
+    public static class PremiumRecruitRequest {
+        private String title;
+        private Address address;
+        private List<String> businessFields;
+        private Double latitude;
+        private Double longitude;
+        private LocalDate recruitStartDate;
+        private LocalDate recruitEndDate;
+        private Integer recruitCount;
+        private String gender;
+        private String education;
+        private String otherConditions;
+        private List<String> preferredConditions;
+        private String workDuration;
+        private String workTime;
+        private String workDays;
+        private String workDaysOther;
+        private String salary;
+        private String salaryType;
+        private List<String> applicationMethods;
+
+        private List<PortfolioRequest> portfolios;
+
+        @Getter
+        @Builder
+        public static class PortfolioRequest {
+            private String title;
+            private PortfolioType type;
+            private boolean isRequired;
+            private Integer maxFileCount;
+            private Long maxFileSize;
+        }
+    }
+}

--- a/src/main/java/com/core/foreign/api/recruit/dto/RecruitResponseDTO.java
+++ b/src/main/java/com/core/foreign/api/recruit/dto/RecruitResponseDTO.java
@@ -1,0 +1,51 @@
+package com.core.foreign.api.recruit.dto;
+
+import com.core.foreign.api.member.entity.Address;
+import com.core.foreign.api.recruit.entity.PortfolioType;
+import com.core.foreign.api.recruit.entity.RecruitType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class RecruitResponseDTO {
+    private Long id;                       // 공고 ID
+    private Address address;               // 주소
+    private String title;                  // 공고 제목
+    private RecruitType recruitType;       // 공고 유형 (GENERAL, PREMIUM 등)
+    private LocalDate recruitStartDate;    // 모집 시작일
+    private LocalDate recruitEndDate;      // 모집 종료일
+    private Integer recruitCount;          // 모집 인원
+    private String gender;                 // 성별
+    private String education;              // 학력 조건
+    private String otherConditions;        // 기타 조건
+    private List<String> preferredConditions; // 우대 조건 리스트
+    private String workDuration;           // 근무 기간
+    private String workTime;               // 근무 시간
+    private String workDays;               // 근무 요일
+    private String workDaysOther;          // 근무 요일 기타 사항
+    private String salary;                 // 급여 정보
+    private String salaryType;             // 급여 형태 (월급, 시급 등)
+    private List<String> businessFields;   // 업직종 리스트
+    private List<String> applicationMethods; // 지원 방법
+    private String posterImageUrl;         // 포스터 이미지 URL
+    private Double latitude;               // 위도
+    private Double longitude;              // 경도
+    private List<PortfolioDTO> portfolios; // 포트폴리오 데이터 (프리미엄 공고만)
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class PortfolioDTO {
+        private String title;              // 포트폴리오 제목
+        private PortfolioType type;        // 포트폴리오 유형 (장문형, 단답형, 파일 업로드)
+        private boolean isRequired;        // 필수 여부
+        private Integer maxFileCount;      // 최대 파일 개수
+        private Long maxFileSize;          // 최대 파일 크기
+    }
+}

--- a/src/main/java/com/core/foreign/api/recruit/entity/GeneralRecruit.java
+++ b/src/main/java/com/core/foreign/api/recruit/entity/GeneralRecruit.java
@@ -1,0 +1,72 @@
+package com.core.foreign.api.recruit.entity;
+
+import com.core.foreign.api.member.entity.Address;
+import com.core.foreign.api.member.entity.Member;
+import jakarta.persistence.Entity;
+import jakarta.persistence.PrimaryKeyJoinColumn;
+import jakarta.persistence.Table;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Entity
+@Table(name = "general_recruit")
+@PrimaryKeyJoinColumn(name = "id")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GeneralRecruit extends Recruit {
+
+    @Builder(toBuilder = true)
+    public GeneralRecruit(
+            String title,
+            Member employer,
+            Address address,
+            List<String> businessFields,
+            Double latitude,
+            Double longitude,
+            LocalDate recruitStartDate,
+            LocalDate recruitEndDate,
+            Integer recruitCount,
+            String gender,
+            String education,
+            String otherConditions,
+            List<String> preferredConditions,
+            String workDuration,
+            String workTime,
+            String workDays,
+            String workDaysOther,
+            String salary,
+            String salaryType,
+            List<String> applicationMethods,
+            String posterImageUrl,
+            RecruitPublishStatus recruitPublishStatus
+    ) {
+        super(
+                title,
+                employer,
+                address,
+                businessFields,
+                latitude,
+                longitude,
+                recruitStartDate,
+                recruitEndDate,
+                recruitCount,
+                gender,
+                education,
+                otherConditions,
+                preferredConditions,
+                workDuration,
+                workTime,
+                workDays,
+                workDaysOther,
+                salary,
+                salaryType,
+                applicationMethods,
+                RecruitType.GENERAL,
+                posterImageUrl,
+                recruitPublishStatus
+        );
+    }
+
+}

--- a/src/main/java/com/core/foreign/api/recruit/entity/Portfolio.java
+++ b/src/main/java/com/core/foreign/api/recruit/entity/Portfolio.java
@@ -1,0 +1,52 @@
+package com.core.foreign.api.recruit.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "portfolio")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Portfolio {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // 질문 ID
+
+    private String title; // 질문 제목
+
+    @Enumerated(EnumType.STRING)
+    private PortfolioType type; // 질문 유형 (장문형, 단답형, 파일 업로드)
+
+    private boolean isRequired; // 필수 여부
+
+    // 파일 업로드 관련 필드
+    private Integer maxFileCount; // 최대 업로드 가능 파일 갯수
+    private Long maxFileSize; // 바이트 단위
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "premium_recruit_id", nullable = false)
+    private PremiumRecruit premiumRecruit;
+
+    @Builder
+    public Portfolio(
+            String title,
+            PortfolioType type,
+            boolean isRequired,
+            Integer maxFileCount,
+            Long maxFileSize
+    ) {
+        this.title = title;
+        this.type = type;
+        this.isRequired = isRequired;
+        this.maxFileCount = maxFileCount;
+        this.maxFileSize = maxFileSize;
+    }
+
+    public void assignPremiumRecruit(PremiumRecruit premiumRecruit) {
+        this.premiumRecruit = premiumRecruit;
+    }
+}

--- a/src/main/java/com/core/foreign/api/recruit/entity/PortfolioType.java
+++ b/src/main/java/com/core/foreign/api/recruit/entity/PortfolioType.java
@@ -1,0 +1,7 @@
+package com.core.foreign.api.recruit.entity;
+
+public enum PortfolioType {
+    LONG_TEXT, // 장문형
+    SHORT_TEXT, // 단답형
+    FILE_UPLOAD // 파일 업로드
+}

--- a/src/main/java/com/core/foreign/api/recruit/entity/PremiumRecruit.java
+++ b/src/main/java/com/core/foreign/api/recruit/entity/PremiumRecruit.java
@@ -1,0 +1,87 @@
+package com.core.foreign.api.recruit.entity;
+
+import com.core.foreign.api.member.entity.Address;
+import com.core.foreign.api.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "premium_recruit")
+@PrimaryKeyJoinColumn(name = "id")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PremiumRecruit extends Recruit {
+
+    @OneToMany(mappedBy = "premiumRecruit", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Portfolio> portfolios = new ArrayList<>();
+
+    @Builder(toBuilder = true)
+    public PremiumRecruit(
+            String title,
+            Member employer,
+            Address address,
+            List<String> businessFields,
+            Double latitude,
+            Double longitude,
+            LocalDate recruitStartDate,
+            LocalDate recruitEndDate,
+            Integer recruitCount,
+            String gender,
+            String education,
+            String otherConditions,
+            List<String> preferredConditions,
+            String workDuration,
+            String workTime,
+            String workDays,
+            String workDaysOther,
+            String salary,
+            String salaryType,
+            List<String> applicationMethods,
+            String posterImageUrl,
+            RecruitPublishStatus recruitPublishStatus
+    ) {
+        super(
+                title,
+                employer,
+                address,
+                businessFields,
+                latitude,
+                longitude,
+                recruitStartDate,
+                recruitEndDate,
+                recruitCount,
+                gender,
+                education,
+                otherConditions,
+                preferredConditions,
+                workDuration,
+                workTime,
+                workDays,
+                workDaysOther,
+                salary,
+                salaryType,
+                applicationMethods,
+                RecruitType.PREMIUM,
+                posterImageUrl,
+                recruitPublishStatus
+        );
+    }
+
+    public void addPortfolio(Portfolio portfolio) {
+        portfolios.add(portfolio);
+        portfolio.assignPremiumRecruit(this);
+    }
+
+    public void addPortfolios(List<Portfolio> portfolioList) {
+        for (Portfolio portfolio : portfolioList) {
+            this.addPortfolio(portfolio);
+        }
+    }
+}

--- a/src/main/java/com/core/foreign/api/recruit/entity/Recruit.java
+++ b/src/main/java/com/core/foreign/api/recruit/entity/Recruit.java
@@ -1,0 +1,121 @@
+package com.core.foreign.api.recruit.entity;
+
+import com.core.foreign.api.member.entity.Address;
+import com.core.foreign.api.member.entity.Member;
+import com.core.foreign.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Entity
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Inheritance(strategy = InheritanceType.JOINED)
+@Table(name = "recruit")
+public abstract class Recruit extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    protected Long id; // 공고 ID
+
+    protected String title; // 공고 제목
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "employer_id", nullable = false)
+    protected Member employer; // 고용주 정보
+
+    protected Double latitude; // 근무지의 위도
+    protected Double longitude; // 근무지의 경도
+
+    protected LocalDate recruitStartDate; // 모집 시작일
+    protected LocalDate recruitEndDate; // 모집 종료일
+
+    protected Integer recruitCount; // 모집 인원
+    protected String gender; // 지원자 성별 조건
+    protected String education; // 학력 조건
+    protected String otherConditions; // 기타 조건
+
+    @Embedded
+    protected Address address; // 주소
+
+    @ElementCollection
+    @CollectionTable(name = "recruit_business_fields", joinColumns = @JoinColumn(name = "recruit_id"))
+    @Column(name = "business_field", length = 100)
+    protected List<String> businessFields; // 업직종 리스트
+
+    @ElementCollection
+    @CollectionTable(name = "recruit_preferred_conditions", joinColumns = @JoinColumn(name = "recruit_id"))
+    @Column(name = "condition", length = 100)
+    protected List<String> preferredConditions; // 우대 조건 리스트
+
+    @ElementCollection
+    @CollectionTable(name = "recruit_application_methods", joinColumns = @JoinColumn(name = "recruit_id"))
+    @Column(name = "method", length = 50)
+    protected List<String> applicationMethods; // 지원 방법 리스트
+
+    protected String workDuration; // 근무 기간
+    protected String workTime; // 근무 시간
+    protected String workDays; // 근무 요일
+    protected String workDaysOther; // 근무 요일 기타 사항 (추가 조건)
+    protected String salary; // 급여 정보
+    protected String salaryType; // 급여 형태 (월급, 시급 등)
+    protected String posterImageUrl; // 포스터 이미지 URL
+
+    @Enumerated(EnumType.STRING)
+    protected RecruitType recruitType; // 공고 유형 (GENERAL, PREMIUM)
+
+    @Enumerated(EnumType.STRING)
+    protected RecruitPublishStatus recruitPublishStatus; // 공고 상태 (PUBLISHED, DRAFT)
+
+    protected Recruit(String title,
+                      Member employer,
+                      Address address,
+                      List<String> businessFields,
+                      Double latitude,
+                      Double longitude,
+                      LocalDate recruitStartDate,
+                      LocalDate recruitEndDate,
+                      Integer recruitCount,
+                      String gender,
+                      String education,
+                      String otherConditions,
+                      List<String> preferredConditions,
+                      String workDuration,
+                      String workTime,
+                      String workDays,
+                      String workDaysOther,
+                      String salary,
+                      String salaryType,
+                      List<String> applicationMethods,
+                      RecruitType recruitType,
+                      String posterImageUrl,
+                      RecruitPublishStatus recruitPublishStatus
+    ) {
+        this.title = title;
+        this.employer = employer;
+        this.address = address;
+        this.businessFields = businessFields;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.recruitStartDate = recruitStartDate;
+        this.recruitEndDate = recruitEndDate;
+        this.recruitCount = recruitCount;
+        this.gender = gender;
+        this.education = education;
+        this.otherConditions = otherConditions;
+        this.preferredConditions = preferredConditions;
+        this.workDuration = workDuration;
+        this.workTime = workTime;
+        this.workDays = workDays;
+        this.workDaysOther = workDaysOther;
+        this.salary = salary;
+        this.salaryType = salaryType;
+        this.applicationMethods = applicationMethods;
+        this.recruitType = recruitType;
+        this.posterImageUrl = posterImageUrl;
+        this.recruitPublishStatus = recruitPublishStatus;
+    }
+}

--- a/src/main/java/com/core/foreign/api/recruit/entity/RecruitPublishStatus.java
+++ b/src/main/java/com/core/foreign/api/recruit/entity/RecruitPublishStatus.java
@@ -1,0 +1,6 @@
+package com.core.foreign.api.recruit.entity;
+
+public enum RecruitPublishStatus {
+    DRAFT,       // 임시저장
+    PUBLISHED    // 최종 등록
+}

--- a/src/main/java/com/core/foreign/api/recruit/entity/RecruitType.java
+++ b/src/main/java/com/core/foreign/api/recruit/entity/RecruitType.java
@@ -1,0 +1,6 @@
+package com.core.foreign.api.recruit.entity;
+
+public enum RecruitType {
+    GENERAL, // 일반 공고
+    PREMIUM // 프리미엄 공고
+}

--- a/src/main/java/com/core/foreign/api/recruit/repository/PortfolioRepository.java
+++ b/src/main/java/com/core/foreign/api/recruit/repository/PortfolioRepository.java
@@ -1,0 +1,7 @@
+package com.core.foreign.api.recruit.repository;
+
+import com.core.foreign.api.recruit.entity.Portfolio;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PortfolioRepository extends JpaRepository<Portfolio, Long> {
+}

--- a/src/main/java/com/core/foreign/api/recruit/repository/RecruitRepository.java
+++ b/src/main/java/com/core/foreign/api/recruit/repository/RecruitRepository.java
@@ -1,0 +1,12 @@
+package com.core.foreign.api.recruit.repository;
+
+import com.core.foreign.api.member.entity.Member;
+import com.core.foreign.api.recruit.entity.Recruit;
+import com.core.foreign.api.recruit.entity.RecruitPublishStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RecruitRepository extends JpaRepository<Recruit, Long> {
+    Optional<Recruit> findAllByEmployerAndRecruitPublishStatus(Member employer, RecruitPublishStatus status);
+}

--- a/src/main/java/com/core/foreign/api/recruit/service/RecruitService.java
+++ b/src/main/java/com/core/foreign/api/recruit/service/RecruitService.java
@@ -1,0 +1,411 @@
+package com.core.foreign.api.recruit.service;
+
+import com.core.foreign.api.aws.service.S3Service;
+import com.core.foreign.api.member.entity.Member;
+import com.core.foreign.api.member.repository.MemberRepository;
+import com.core.foreign.api.recruit.dto.RecruitRequestDTO;
+import com.core.foreign.api.recruit.entity.*;
+import com.core.foreign.api.recruit.repository.RecruitRepository;
+import com.core.foreign.api.recruit.dto.RecruitResponseDTO;
+import com.core.foreign.common.exception.BadRequestException;
+import com.core.foreign.common.exception.InternalServerException;
+import com.core.foreign.common.exception.NotFoundException;
+import com.core.foreign.common.response.ErrorStatus;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class RecruitService {
+
+    private final RecruitRepository recruitRepository;
+    private final MemberRepository memberRepository;
+    private final S3Service s3Service;
+
+    // 일반 공고 등록
+    @Transactional
+    public void createGeneralRecruit(
+            Long memberId,
+            RecruitRequestDTO.GeneralRecruitRequest request,
+            MultipartFile posterImage
+    ) {
+        Member employer = getEmployer(memberId);
+        // 포스터 이미지 업로드
+        String posterImageUrl = uploadPosterImage(posterImage);
+
+        GeneralRecruit generalRecruit = GeneralRecruit.builder()
+                .title(request.getTitle())
+                .address(request.getAddress())
+                .employer(employer)
+                .businessFields(new ArrayList<>(request.getBusinessFields()))
+                .latitude(request.getLatitude())
+                .longitude(request.getLongitude())
+                .recruitStartDate(request.getRecruitStartDate())
+                .recruitEndDate(request.getRecruitEndDate())
+                .recruitCount(request.getRecruitCount())
+                .gender(request.getGender())
+                .education(request.getEducation())
+                .otherConditions(request.getOtherConditions())
+                .preferredConditions(new ArrayList<>(request.getPreferredConditions()))
+                .workDuration(request.getWorkDuration())
+                .workTime(request.getWorkTime())
+                .workDays(request.getWorkDays())
+                .workDaysOther(request.getWorkDaysOther())
+                .salary(request.getSalary())
+                .salaryType(request.getSalaryType())
+                .applicationMethods(new ArrayList<>(request.getApplicationMethods()))
+                .posterImageUrl(posterImageUrl)
+                .recruitPublishStatus(RecruitPublishStatus.PUBLISHED)
+                .build();
+
+        recruitRepository.save(generalRecruit);
+    }
+
+    // 프리미엄 공고 등록
+    @Transactional
+    public void createPremiumRecruit(
+            Long memberId,
+            RecruitRequestDTO.PremiumRecruitRequest request,
+            MultipartFile posterImage
+    ) {
+        Member employer = getEmployer(memberId);
+        // 포스터 이미지 업로드
+        String posterImageUrl = uploadPosterImage(posterImage);
+
+        PremiumRecruit premiumRecruit = PremiumRecruit.builder()
+                .title(request.getTitle())
+                .address(request.getAddress())
+                .employer(employer)
+                .businessFields(new ArrayList<>(request.getBusinessFields()))
+                .latitude(request.getLatitude())
+                .longitude(request.getLongitude())
+                .recruitStartDate(request.getRecruitStartDate())
+                .recruitEndDate(request.getRecruitEndDate())
+                .recruitCount(request.getRecruitCount())
+                .gender(request.getGender())
+                .education(request.getEducation())
+                .otherConditions(request.getOtherConditions())
+                .preferredConditions(new ArrayList<>(request.getPreferredConditions()))
+                .workDuration(request.getWorkDuration())
+                .workTime(request.getWorkTime())
+                .workDays(request.getWorkDays())
+                .workDaysOther(request.getWorkDaysOther())
+                .salary(request.getSalary())
+                .salaryType(request.getSalaryType())
+                .applicationMethods(new ArrayList<>(request.getApplicationMethods()))
+                .posterImageUrl(posterImageUrl)
+                .recruitPublishStatus(RecruitPublishStatus.PUBLISHED)
+                .build();
+
+        List<Portfolio> portfolios = request.getPortfolios().stream()
+                .map(p -> Portfolio.builder()
+                        .title(p.getTitle())
+                        .type(p.getType())
+                        .isRequired(p.isRequired())
+                        .maxFileCount(p.getMaxFileCount())
+                        .maxFileSize(p.getMaxFileSize())
+                        .build())
+                .toList();
+
+        portfolios.forEach(premiumRecruit::addPortfolio);
+        recruitRepository.save(premiumRecruit);
+    }
+
+    // 일반 공고 임시저장
+    @Transactional
+    public void saveGeneralRecruitDraft(
+            Long memberId,
+            RecruitRequestDTO.GeneralRecruitRequest request,
+            MultipartFile posterImage
+    ) {
+        Member employer = getEmployer(memberId);
+
+        // 임시 저장 한 데이터 삭제
+        deleteDraft(employer);
+
+        // 포스터 이미지 업로드
+        String posterImageUrl = uploadPosterImage(posterImage);
+
+        GeneralRecruit draftRecruit = GeneralRecruit.builder()
+                .title(request.getTitle())
+                .address(request.getAddress())
+                .employer(employer)
+                .businessFields(new ArrayList<>(request.getBusinessFields()))
+                .latitude(request.getLatitude())
+                .longitude(request.getLongitude())
+                .recruitStartDate(request.getRecruitStartDate())
+                .recruitEndDate(request.getRecruitEndDate())
+                .recruitCount(request.getRecruitCount())
+                .gender(request.getGender())
+                .education(request.getEducation())
+                .otherConditions(request.getOtherConditions())
+                .preferredConditions(new ArrayList<>(request.getPreferredConditions()))
+                .workDuration(request.getWorkDuration())
+                .workTime(request.getWorkTime())
+                .workDays(request.getWorkDays())
+                .workDaysOther(request.getWorkDaysOther())
+                .salary(request.getSalary())
+                .salaryType(request.getSalaryType())
+                .applicationMethods(new ArrayList<>(request.getApplicationMethods()))
+                .posterImageUrl(posterImageUrl)
+                .recruitPublishStatus(RecruitPublishStatus.DRAFT)
+                .build();
+
+        recruitRepository.save(draftRecruit);
+    }
+
+    // 프리미엄 공고 임시저장
+    @Transactional
+    public void savePremiumRecruitDraft(
+            Long memberId,
+            RecruitRequestDTO.PremiumRecruitRequest request,
+            MultipartFile posterImage
+    ) {
+        Member employer = getEmployer(memberId);
+
+        // 임시 저장 한 데이터 삭제
+        deleteDraft(employer);
+
+        // 포스터 이미지 업로드
+        String posterImageUrl = uploadPosterImage(posterImage);
+
+        PremiumRecruit draftRecruit = PremiumRecruit.builder()
+                .title(request.getTitle())
+                .address(request.getAddress())
+                .employer(employer)
+                .businessFields(new ArrayList<>(request.getBusinessFields()))
+                .latitude(request.getLatitude())
+                .longitude(request.getLongitude())
+                .recruitStartDate(request.getRecruitStartDate())
+                .recruitEndDate(request.getRecruitEndDate())
+                .recruitCount(request.getRecruitCount())
+                .gender(request.getGender())
+                .education(request.getEducation())
+                .otherConditions(request.getOtherConditions())
+                .preferredConditions(new ArrayList<>(request.getPreferredConditions()))
+                .workDuration(request.getWorkDuration())
+                .workTime(request.getWorkTime())
+                .workDays(request.getWorkDays())
+                .workDaysOther(request.getWorkDaysOther())
+                .salary(request.getSalary())
+                .salaryType(request.getSalaryType())
+                .applicationMethods(new ArrayList<>(request.getApplicationMethods()))
+                .posterImageUrl(posterImageUrl)
+                .recruitPublishStatus(RecruitPublishStatus.DRAFT)
+                .build();
+
+        List<Portfolio> portfolios = request.getPortfolios().stream()
+                .map(p -> Portfolio.builder()
+                        .title(p.getTitle())
+                        .type(p.getType())
+                        .isRequired(p.isRequired())
+                        .maxFileCount(p.getMaxFileCount())
+                        .maxFileSize(p.getMaxFileSize())
+                        .build())
+                .toList();
+
+        portfolios.forEach(draftRecruit::addPortfolio);
+        recruitRepository.save(draftRecruit);
+    }
+
+    // 일반 공고 퍼블리싱
+    @Transactional
+    public void publishGeneralRecruit(
+            Long recruitId,
+            RecruitRequestDTO.GeneralRecruitRequest request,
+            MultipartFile posterImage
+    ) {
+        GeneralRecruit recruit = getGeneralRecruit(recruitId);
+        validateDraftStatus(recruit);
+
+        // 이전 데이터 삭제
+        recruitRepository.delete(recruit);
+
+        // 포스터 이미지 업로드
+        String posterImageUrl = uploadPosterImage(posterImage);
+
+        GeneralRecruit newRecruit = GeneralRecruit.builder()
+                .title(request.getTitle())
+                .address(request.getAddress())
+                .employer(recruit.getEmployer())
+                .businessFields(new ArrayList<>(request.getBusinessFields()))
+                .latitude(request.getLatitude())
+                .longitude(request.getLongitude())
+                .recruitStartDate(request.getRecruitStartDate())
+                .recruitEndDate(request.getRecruitEndDate())
+                .recruitCount(request.getRecruitCount())
+                .gender(request.getGender())
+                .education(request.getEducation())
+                .otherConditions(request.getOtherConditions())
+                .preferredConditions(new ArrayList<>(request.getPreferredConditions()))
+                .workDuration(request.getWorkDuration())
+                .workTime(request.getWorkTime())
+                .workDays(request.getWorkDays())
+                .workDaysOther(request.getWorkDaysOther())
+                .salary(request.getSalary())
+                .salaryType(request.getSalaryType())
+                .applicationMethods(new ArrayList<>(request.getApplicationMethods()))
+                .posterImageUrl(posterImageUrl)
+                .recruitPublishStatus(RecruitPublishStatus.PUBLISHED)
+                .build();
+
+        recruitRepository.save(newRecruit);
+    }
+
+    // 프리미엄 공고 퍼블리싱
+    @Transactional
+    public void publishPremiumRecruit(
+            Long recruitId,
+            RecruitRequestDTO.PremiumRecruitRequest request,
+            MultipartFile posterImage
+    ) {
+        PremiumRecruit recruit = getPremiumRecruit(recruitId);
+        validateDraftStatus(recruit);
+
+        // 이전 데이터 삭제
+        recruitRepository.delete(recruit);
+
+        // 포스터 이미지 업로드
+        String posterImageUrl = uploadPosterImage(posterImage);
+
+        PremiumRecruit newRecruit = PremiumRecruit.builder()
+                .title(request.getTitle())
+                .address(request.getAddress())
+                .employer(recruit.getEmployer())
+                .businessFields(new ArrayList<>(request.getBusinessFields()))
+                .latitude(request.getLatitude())
+                .longitude(request.getLongitude())
+                .recruitStartDate(request.getRecruitStartDate())
+                .recruitEndDate(request.getRecruitEndDate())
+                .recruitCount(request.getRecruitCount())
+                .gender(request.getGender())
+                .education(request.getEducation())
+                .otherConditions(request.getOtherConditions())
+                .preferredConditions(new ArrayList<>(request.getPreferredConditions()))
+                .workDuration(request.getWorkDuration())
+                .workTime(request.getWorkTime())
+                .workDays(request.getWorkDays())
+                .workDaysOther(request.getWorkDaysOther())
+                .salary(request.getSalary())
+                .salaryType(request.getSalaryType())
+                .applicationMethods(new ArrayList<>(request.getApplicationMethods()))
+                .posterImageUrl(posterImageUrl)
+                .recruitPublishStatus(RecruitPublishStatus.PUBLISHED)
+                .build();
+
+        // Portfolio 추가
+        List<Portfolio> portfolios = request.getPortfolios().stream()
+                .map(p -> Portfolio.builder()
+                        .title(p.getTitle())
+                        .type(p.getType())
+                        .isRequired(p.isRequired())
+                        .maxFileCount(p.getMaxFileCount())
+                        .maxFileSize(p.getMaxFileSize())
+                        .build())
+                .toList();
+        portfolios.forEach(newRecruit::addPortfolio);
+
+        recruitRepository.save(newRecruit);
+    }
+
+    // 사용자 임시저장 데이터 조회
+    @Transactional
+    public List<RecruitResponseDTO> getDrafts(Long memberId) {
+        Member employer = getEmployer(memberId);
+        Optional<Recruit> drafts = recruitRepository.findAllByEmployerAndRecruitPublishStatus(employer, RecruitPublishStatus.DRAFT);
+
+        return drafts.stream()
+                .map(draft -> {
+                    List<RecruitResponseDTO.PortfolioDTO> portfolioDTOs = new ArrayList<>();
+                    if (draft instanceof PremiumRecruit premiumRecruit) {
+                        portfolioDTOs = premiumRecruit.getPortfolios().stream()
+                                .map(portfolio -> RecruitResponseDTO.PortfolioDTO.builder()
+                                        .title(portfolio.getTitle())
+                                        .type(portfolio.getType())
+                                        .isRequired(portfolio.isRequired())
+                                        .maxFileCount(portfolio.getMaxFileCount())
+                                        .maxFileSize(portfolio.getMaxFileSize())
+                                        .build())
+                                .toList();
+                    }
+
+                    return RecruitResponseDTO.builder()
+                            .id(draft.getId())
+                            .title(draft.getTitle())
+                            .address(draft.getAddress())
+                            .recruitType(draft.getRecruitType())
+                            .recruitStartDate(draft.getRecruitStartDate())
+                            .recruitEndDate(draft.getRecruitEndDate())
+                            .recruitCount(draft.getRecruitCount())
+                            .gender(draft.getGender())
+                            .education(draft.getEducation())
+                            .otherConditions(draft.getOtherConditions())
+                            .preferredConditions(draft.getPreferredConditions())
+                            .workDuration(draft.getWorkDuration())
+                            .workTime(draft.getWorkTime())
+                            .workDays(draft.getWorkDays())
+                            .workDaysOther(draft.getWorkDaysOther())
+                            .salary(draft.getSalary())
+                            .salaryType(draft.getSalaryType())
+                            .businessFields(draft.getBusinessFields())
+                            .applicationMethods(draft.getApplicationMethods())
+                            .posterImageUrl(draft.getPosterImageUrl())
+                            .latitude(draft.getLatitude())
+                            .longitude(draft.getLongitude())
+                            .portfolios(portfolioDTOs)
+                            .build();
+                })
+                .toList();
+    }
+
+    // 사용자 조회
+    private Member getEmployer(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.USERID_NOT_FOUND_EXCEPTION.getMessage()));
+    }
+
+    // 기존 임시 저장 데이터 삭제
+    @Transactional
+    protected void deleteDraft(Member employer) {
+        recruitRepository.findAllByEmployerAndRecruitPublishStatus(employer, RecruitPublishStatus.DRAFT)
+                .ifPresent(recruitRepository::delete);
+    }
+
+    // 포스터 이미지 업로드
+    private String uploadPosterImage(MultipartFile posterImage) {
+        if (posterImage != null && !posterImage.isEmpty()) {
+            try {
+                return s3Service.uploadRecruitPostImage(posterImage);
+            } catch (IOException e) {
+                throw new InternalServerException(ErrorStatus.FAIL_UPLOAD_EXCEPTION.getMessage());
+            }
+        }
+        return null;
+    }
+
+    // 공고 상태 확인
+    private void validateDraftStatus(Recruit recruit) {
+        if (!RecruitPublishStatus.DRAFT.equals(recruit.getRecruitPublishStatus())) {
+            throw new BadRequestException(ErrorStatus.ALEADY_PUBLISHED_RECRUIT_ARTICLE_EXCEPTION.getMessage());
+        }
+    }
+
+    // 일반 공고 조회
+    private GeneralRecruit getGeneralRecruit(Long recruitId) {
+        return (GeneralRecruit) recruitRepository.findById(recruitId)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.RECRUIT_NOT_FOUND_EXCEPTION.getMessage()));
+    }
+
+    // 프리미엄 공고 조회
+    private PremiumRecruit getPremiumRecruit(Long recruitId) {
+        return (PremiumRecruit) recruitRepository.findById(recruitId)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.RECRUIT_NOT_FOUND_EXCEPTION.getMessage()));
+    }
+}

--- a/src/main/java/com/core/foreign/common/config/SwaggerBeanConfig.java
+++ b/src/main/java/com/core/foreign/common/config/SwaggerBeanConfig.java
@@ -1,0 +1,17 @@
+package com.core.foreign.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+
+import java.util.ArrayList;
+
+@Configuration
+public class SwaggerBeanConfig {
+
+    public SwaggerBeanConfig(MappingJackson2HttpMessageConverter converter) {
+        var supportedMediaTypes = new ArrayList<>(converter.getSupportedMediaTypes());
+        supportedMediaTypes.add(new MediaType("application", "octet-stream"));
+        converter.setSupportedMediaTypes(supportedMediaTypes);
+    }
+}

--- a/src/main/java/com/core/foreign/common/config/aws/S3Config.java
+++ b/src/main/java/com/core/foreign/common/config/aws/S3Config.java
@@ -1,0 +1,31 @@
+package com.core.foreign.common.config.aws;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        AwsBasicCredentials awsCreds = AwsBasicCredentials.create(accessKey, secretKey);
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(awsCreds))
+                .build();
+    }
+}

--- a/src/main/java/com/core/foreign/common/response/ErrorStatus.java
+++ b/src/main/java/com/core/foreign/common/response/ErrorStatus.java
@@ -20,6 +20,9 @@ public enum ErrorStatus {
     WRONG_EMAIL_VERIFICATION_CODE_EXCEPTION(HttpStatus.BAD_REQUEST,"이메일 인증코드가 올바르지 않습니다."),
     VALIDATION_EMAIL_FORMAT_EXCEPTION(HttpStatus.BAD_REQUEST,"올바른 이메일 형식이 아닙니다."),
     MISSING_EMAIL_VERIFICATION_EXCPETION(HttpStatus.BAD_REQUEST,"이메일 인증을 진행해주세요."),
+    ONLY_ADD_RECRUIT_ARTICLE_EMPLOYER_EXCEPTION(HttpStatus.BAD_REQUEST,"고용주만 공고 등록이 가능합니다."),
+    NOT_ENOUGH_PREMIUM_COUNT_EXCEPTION(HttpStatus.BAD_REQUEST,"프리미엄 공고 등록 가능 횟수가 부족합니다."),
+    ALEADY_PUBLISHED_RECRUIT_ARTICLE_EXCEPTION(HttpStatus.BAD_REQUEST,"이미 퍼블리싱된 공고 입니다."),
 
     /**
      * 401 UNAUTHORIZED
@@ -33,11 +36,12 @@ public enum ErrorStatus {
      */
 
     USERID_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 아이디를 찾을 수 없습니다."),
+    RECRUIT_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND,"해당 공고를 찾을 수 없습니다."),
 
     /**
      * 500 SERVER_ERROR
      */
-
+    FAIL_UPLOAD_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR,"파일 업로드 실패하였습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/core/foreign/common/response/SuccessStatus.java
+++ b/src/main/java/com/core/foreign/common/response/SuccessStatus.java
@@ -22,11 +22,15 @@ public enum SuccessStatus {
     SEND_SELECT_EMPLOYER_SUCCESS(HttpStatus.OK, "고용주 조회 성공"),
     SEND_EMAIL_DUPLICATION_SUCCESS(HttpStatus.OK,"사용 가능한 이메일"),
     SEND_SELECT_EMPLOYER_COMPANY_INFO_SUCCESS(HttpStatus.OK,"고용주 회사 정보 조회 성공"),
+    SEND_NO_DRAFT_SAVE_SUCCESS(HttpStatus.OK,"임시 저장된 공고가 없습니다."),
+    SEND_DRAFT_SAVE_SUCCESS(HttpStatus.OK,"임시 저장된 공고 조회 성공"),
 
     /**
      * 201
      */
-    CREATE_ARTICLE_SUCCESS(HttpStatus.CREATED, "게시판 등록 성공"),
+    CREATE_RECRUIT_ARTICLE_SUCCESS(HttpStatus.CREATED, "공고 등록 성공"),
+    CREATE_DRAFT_RECRUIT_ARTICLE_SUCCESS(HttpStatus.CREATED, "공고 임시 저장 성공"),
+
 
     ;
 


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #6

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 일반 / 프리미엄 채용 공고 등록, 임시 저장 기능을 구현하였습니다.
- 사용자의 임시 저장 된 공고가 존재한다면 해당 데이터를 불러오는 기능을 구현하였습니다.
- S3 버킷 구축 및 연동하였습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
![image](https://github.com/user-attachments/assets/2fcc9238-ef69-48b3-98f0-8cd7956aeea5)
