### PR TITLE
[FIX] 공고 임시등록 조회 로직 수정

### DIFF
--- a/src/main/java/com/core/foreign/api/recruit/controller/RecruitController.java
+++ b/src/main/java/com/core/foreign/api/recruit/controller/RecruitController.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 @Tag(name = "Recruit", description = "공고 관련 API 입니다.<br>" +
         "<p>" +
-        "[사용자 임시저장 데이터조회 API + 작성 가능 공고 조회 API + 회사 정보 조회 API(마이페이지(고용주)-내 기업 정보) -> 만약 임시저장 데이터 있다면 -> 해당 공고 퍼블리싱 API / 임시 저장 데이터가 없다면 -> 공고 등록 API")
+        "[임시 저장된 공고 존재 여부 조회 API + 작성 가능 공고 조회 API + 회사 정보 조회 API(마이페이지(고용주)-내 기업 정보) -> 만약 임시저장 데이터 있다면 -> 해당 공고 퍼블리싱 API / 임시 저장 데이터가 없다면 -> 공고 등록 API")
 @RestController
 @RequestMapping("/api/v1/recruit")
 @RequiredArgsConstructor
@@ -421,21 +421,33 @@ public class RecruitController {
         return ApiResponse.success_only(SuccessStatus.CREATE_RECRUIT_ARTICLE_SUCCESS);
     }
 
-    @Operation(summary = "사용자 임시저장 데이터 조회 API",
-            description = "임시 저장한 데이터가 있는지 조회합니다.")
+    @Operation(summary = "임시 저장된 공고 존재 여부 조회 API",
+            description = "현재 사용자가 임시 저장한 공고가 존재하는지 여부를 확인합니다.")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "임시 저장된 공고 조회 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "임시 저장된 공고 여부 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다.")
     })
-    @GetMapping("/drafts")
-    public ResponseEntity<ApiResponse<List<RecruitResponseDTO>>> getDrafts(
+    @GetMapping("/drafts/exist")
+    public ResponseEntity<ApiResponse<Boolean>> checkDraftExistence(
             @AuthenticationPrincipal SecurityMember securityMember
     ) {
-        List<RecruitResponseDTO> drafts = recruitService.getDrafts(securityMember.getId());
-        if (drafts.isEmpty()) {
-            return ApiResponse.success(SuccessStatus.SEND_NO_DRAFT_SAVE_SUCCESS, List.of());
-        }
-        return ApiResponse.success(SuccessStatus.SEND_DRAFT_SAVE_SUCCESS, drafts);
+        boolean exists = recruitService.hasDrafts(securityMember.getId());
+        return ApiResponse.success(exists ? SuccessStatus.SEND_DRAFT_SAVE_SUCCESS : SuccessStatus.SEND_NO_DRAFT_SAVE_SUCCESS, exists);
+    }
+
+    @Operation(summary = "임시 저장된 공고 내용 조회 API",
+            description = "해당 임시 공고의 ID를 받아 임시 저장된 공고의 상세 데이터를 반환합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "임시 저장된 공고 내용 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다.")
+    })
+    @GetMapping("/drafts/{recruitId}")
+    public ResponseEntity<ApiResponse<RecruitResponseDTO>> getDraftById(
+            @AuthenticationPrincipal SecurityMember securityMember,
+            @PathVariable("recruitId") Long recruitId
+    ) {
+        RecruitResponseDTO draft = recruitService.getDraftById(recruitId, securityMember.getId());
+        return ApiResponse.success(SuccessStatus.SEND_DRAFT_DETAIL_SUCCESS, draft);
     }
 
     @Operation(summary = "작성 가능 공고 조회 API",

--- a/src/main/java/com/core/foreign/common/response/ErrorStatus.java
+++ b/src/main/java/com/core/foreign/common/response/ErrorStatus.java
@@ -23,7 +23,6 @@ public enum ErrorStatus {
     MISSING_EMAIL_VERIFICATION_EXCEPTION(HttpStatus.BAD_REQUEST,"이메일 인증을 진행해주세요."),
     MISSING_PHONENUMBER_VERIFICATION_EXCEPTION(HttpStatus.BAD_REQUEST,"전화번호 인증을 진행해주세요."),
     ONLY_ADD_RECRUIT_ARTICLE_EMPLOYER_EXCEPTION(HttpStatus.BAD_REQUEST,"고용주만 공고 등록이 가능합니다."),
-    NOT_ENOUGH_PREMIUM_COUNT_EXCEPTION(HttpStatus.BAD_REQUEST,"프리미엄 공고 등록 가능 횟수가 부족합니다."),
     ALEADY_PUBLISHED_RECRUIT_ARTICLE_EXCEPTION(HttpStatus.BAD_REQUEST,"이미 퍼블리싱된 공고 입니다."),
     VALIDATION_PHONE_FORMAT_EXCEPTION(HttpStatus.BAD_REQUEST, "휴대폰 번호 형식이 올바르지 않습니다."),
     WRONG_SMS_VERIFICATION_CODE_EXCEPTION(HttpStatus.BAD_REQUEST,"SMS 인증코드가 올바르지 않습니다."),
@@ -41,10 +40,7 @@ public enum ErrorStatus {
     EXCEEDED_RECRUIT_CAPACITY_EXCEPTION(HttpStatus.BAD_REQUEST, "모집 인원을 초과할 수 없습니다."),
     ALREADY_APPROVED_RESUME_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 승인된 이력서입니다."),
     ALREADY_REJECTED_RESUME_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 거절된 이력서입니다."),
-
-
-
-
+    NOT_DRAFT_RECRUIT_EXCEPTION(HttpStatus.BAD_REQUEST,"해당 공고는 임시 저장 상태가 아닙니다."),
 
     /**
      * 401 UNAUTHORIZED
@@ -54,6 +50,7 @@ public enum ErrorStatus {
     UNAUTHORIZED_EMAIL_VERIFICATION_CODE_EXCEPTION(HttpStatus.UNAUTHORIZED,"이메일 인증코드가 만료되었습니다, 재인증 해주세요."),
     UNAUTHORIZED_SMS_VERIFICATION_CODE_EXCEPTION(HttpStatus.UNAUTHORIZED,"SMS 인증코드가 만료되었습니다, 재인증 해주세요."),
     EXPIRED_PASSWORD_RESET_CODE_EXCEPTION(HttpStatus.UNAUTHORIZED,"비밀번호 초기화 인증코드가 만료되었습니다, 재인증 해주세요."),
+    INVALID_USER_EXCEPTION(HttpStatus.UNAUTHORIZED,"해당 시스템에 접근할 권한이 없습니다."),
 
     /**
      * 404 NOT_FOUND

--- a/src/main/java/com/core/foreign/common/response/SuccessStatus.java
+++ b/src/main/java/com/core/foreign/common/response/SuccessStatus.java
@@ -24,6 +24,7 @@ public enum SuccessStatus {
     SEND_SELECT_EMPLOYER_COMPANY_INFO_SUCCESS(HttpStatus.OK,"고용주 회사 정보 조회 성공"),
     SEND_NO_DRAFT_SAVE_SUCCESS(HttpStatus.OK,"임시 저장된 공고가 없습니다."),
     SEND_DRAFT_SAVE_SUCCESS(HttpStatus.OK,"임시 저장된 공고 조회 성공"),
+    SEND_DRAFT_DETAIL_SUCCESS(HttpStatus.OK,"임시 저장된 공고 내용 조회 성공"),
     SEND_SELECT_EMPLOYEE_BASIC_RESUME_SUCCESS(HttpStatus.OK,"피고용인 기본 이력서 조회 성공"),
     SEND_EMPLOYEE_BASIC_RESUME_UPDATE_SUCCESS(HttpStatus.OK,"피고용인 기본 이력서 수정 성공"),
     SEND_SMS_VERIFICATION_CODE_SUCCESS(HttpStatus.OK,"SMS 인증코드 발송 성공"),
@@ -52,13 +53,6 @@ public enum SuccessStatus {
     DELETE_MY_RESUME_SUCCESS(HttpStatus.OK, "내 이력서 삭제 성공"),
     UPDATE_RECRUIT_BOOKMARK_STATUS_SUCCESS(HttpStatus.OK, "찜하기 상태 변경 성공"),
     SEND_BOOKMARKED_RECRUITS_SUCCESS(HttpStatus.OK, "찜한 공고 조회 성공"),
-
-
-
-
-
-
-
 
 
     /**


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #65

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 기존 임시 등록된 내용 조회 API를 임시 저장된 공고 존재 여부 조회 API / 임시 저장된 공고 내용 조회 API로 분리하였습니다.
- 컨트롤러 스웨거 안내 문구 수정하였습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
[ 임시 저장된 공고 존재 여부 조회 API ]
![image](https://github.com/user-attachments/assets/4feccd93-e0ea-4db6-946e-ab4460a21865)

[ 임시 저장된 공고 내용 조회 API ]
![image](https://github.com/user-attachments/assets/f35e0246-0c0f-4a3f-beba-cc91e3b11477)
