### PR TITLE
[FIX] 고용인 마이페이지 내 공고 수정.

### DIFF
--- a/src/main/java/com/core/foreign/api/recruit/controller/RecruitController.java
+++ b/src/main/java/com/core/foreign/api/recruit/controller/RecruitController.java
@@ -570,30 +570,6 @@ public class RecruitController {
         return ApiResponse.success(SuccessStatus.SEND_RECRUIT_DETAIL_SUCCESS, detailDTO);
     }
 
-    @Operation(summary = "고용인의 내 공고 조회 API",
-            description = "고용인의 내가 등록했던 공고 글을 확인할 수 있는 화면입니다.<br>" +
-                    "<p>" +
-                    "title : 공고 제목<br>" +
-                    "recruitStartDate : 모집 시작일<br>" +
-                    "recruitEndDate : 모집 종료일 / 상시 모집일 경우 2099-12-31<br>" +
-                    "workDuration : 근무 기간<br>" +
-                    "workTime : 근무 시간(직접 선택시 '시작시간~종료시간'<br>" +
-                    "workDays : 근무 요일<br>" +
-                    "recruitType: 공고 유형<br> " +
-                    "isUp: 상단 노출<br>"
-    )
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "공고 조회 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
-    })
-    @GetMapping(value = "/my")
-    public ResponseEntity<ApiResponse<Page<MyRecruitResponseDTO>>> getMyRecruit(@AuthenticationPrincipal SecurityMember securityMember,
-                                                                                @RequestParam("page") Integer page,
-                                                                                @RequestParam("recruitType") RecruitType recruitType) {
-        Page<MyRecruitResponseDTO> myRecruits = recruitService.getMyRecruits(securityMember.getId(), page, recruitType);
-        return ApiResponse.success(SuccessStatus.SEND_EMPLOYER_RECRUIT_LIST_SUCCESS, myRecruits);
-    }
-
     @Operation(summary = "고용인 지원현황 조회 API",
             description = "고용인이 등록한 공고의 지원현황을 조회합니다.<br>"
     )
@@ -748,6 +724,52 @@ public class RecruitController {
         return ApiResponse.success(SuccessStatus.SEND_BOOKMARKED_RECRUITS_SUCCESS, response);
 
     }
+
+    @Operation(summary = "고용인의 내 공고 조회 API",
+            description = "고용인의 내가 등록했던 공고 글을 확인할 수 있는 화면입니다.<br>" +
+                    "<p>" +
+                    "title : 공고 제목<br>" +
+                    "recruitStartDate : 모집 시작일<br>" +
+                    "recruitEndDate : 모집 종료일 / 상시 모집일 경우 2099-12-31<br>" +
+                    "workDuration : 근무 기간<br>" +
+                    "workTime : 근무 시간(직접 선택시 '시작시간~종료시간'<br>" +
+                    "workDays : 근무 요일<br>" +
+                    "recruitType: 공고 유형<br> " +
+                    "isUp: 상단 노출<br>"
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "공고 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+    })
+    @GetMapping(value = "/my")
+    public ResponseEntity<ApiResponse<Page<MyRecruitResponseDTO>>> getMyRecruits(@AuthenticationPrincipal SecurityMember securityMember,
+                                                                         @RequestParam(value = "page", defaultValue = "0") Integer  page,
+                                                                         @RequestParam("size")Integer size,
+                                                                         @RequestParam(value = "recruitType", required = false)RecruitType recruitType,
+                                                                         @RequestParam(value = "excludeExpired", defaultValue = "false")boolean excludeExpired) {
+        Page<MyRecruitResponseDTO> recruits = recruitService.getMyRecruits(securityMember.getId(), page, size, recruitType, excludeExpired);
+
+        return ApiResponse.success(SuccessStatus.SEND_EMPLOYER_RECRUIT_LIST_SUCCESS, recruits);
+
+    }
+
+    @Operation(summary = "고용인 내 임시 공고 공고 조회 API",
+            description = "고용인 내가 등록했던 임시 공고 글을 확인할 수 있는 화면입니다.<br>"
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "공고 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+    })
+    @GetMapping(value = "/draft/my")
+    public ResponseEntity<ApiResponse<Page<MyDraftRecruitResponseDTO>>> getMyDraftRecruits(@AuthenticationPrincipal SecurityMember securityMember,
+                                                                                 @RequestParam(value = "page", defaultValue = "0") Integer  page,
+                                                                                 @RequestParam("size")Integer size) {
+        Page<MyDraftRecruitResponseDTO> recruits = recruitService.getMyDraftRecruits(securityMember.getId(), page, size);
+
+        return ApiResponse.success(SuccessStatus.SEND_EMPLOYER_RECRUIT_LIST_SUCCESS, recruits);
+
+    }
+
 
 
 }

--- a/src/main/java/com/core/foreign/api/recruit/dto/MyDraftRecruitResponseDTO.java
+++ b/src/main/java/com/core/foreign/api/recruit/dto/MyDraftRecruitResponseDTO.java
@@ -1,0 +1,26 @@
+package com.core.foreign.api.recruit.dto;
+
+import com.core.foreign.api.recruit.entity.Recruit;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class MyDraftRecruitResponseDTO {
+    private Long id; // 공고 ID
+    private String title; // 공고 제목
+    private LocalDateTime createdAt;  // 생성 날짜
+    private LocalDateTime updatedAt;  // 수정 날짜
+
+
+
+    public static MyDraftRecruitResponseDTO from(Recruit recruit){
+        MyDraftRecruitResponseDTO dto = new MyDraftRecruitResponseDTO();
+
+        dto.id=recruit.getId();
+        dto.title=recruit.getTitle();
+        dto.createdAt=recruit.getCreatedAt();
+        dto.updatedAt=recruit.getUpdatedAt();
+        return dto;
+    }
+}

--- a/src/main/java/com/core/foreign/api/recruit/dto/MyRecruitResponseDTO.java
+++ b/src/main/java/com/core/foreign/api/recruit/dto/MyRecruitResponseDTO.java
@@ -27,9 +27,18 @@ public class MyRecruitResponseDTO {
         dto.title = recruit.getTitle();
         dto.recruitStartDate=recruit.getRecruitStartDate();
         dto.recruitEndDate=recruit.getRecruitEndDate();
+
+
+/*
         dto.workDuration = recruit.getWorkDuration();
         dto.workDays = recruit.getWorkDays();
         dto.workTime = recruit.getWorkTime();
+*/
+
+        dto.workDuration =null;
+        dto.workDays = null;
+        dto.workTime = null;
+
         dto.recruitType = recruit.getRecruitType();
         dto.isUp=false;
 

--- a/src/main/java/com/core/foreign/api/recruit/repository/RecruitRepository.java
+++ b/src/main/java/com/core/foreign/api/recruit/repository/RecruitRepository.java
@@ -16,7 +16,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.Optional;
 
 public interface RecruitRepository
-        extends JpaRepository<Recruit, Long>, JpaSpecificationExecutor<Recruit> {
+        extends JpaRepository<Recruit, Long>, JpaSpecificationExecutor<Recruit>, RecruitRepositoryQueryDSL {
 
     Optional<Recruit> findAllByEmployerAndRecruitPublishStatus(Member employer, RecruitPublishStatus status);
 

--- a/src/main/java/com/core/foreign/api/recruit/repository/RecruitRepositoryImpl.java
+++ b/src/main/java/com/core/foreign/api/recruit/repository/RecruitRepositoryImpl.java
@@ -1,0 +1,66 @@
+package com.core.foreign.api.recruit.repository;
+
+import com.core.foreign.api.recruit.entity.QRecruit;
+import com.core.foreign.api.recruit.entity.Recruit;
+import com.core.foreign.api.recruit.entity.RecruitPublishStatus;
+import com.core.foreign.api.recruit.entity.RecruitType;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static com.core.foreign.api.recruit.entity.QRecruit.recruit;
+
+public class RecruitRepositoryImpl implements RecruitRepositoryQueryDSL{
+    private final JPAQueryFactory queryFactory;
+
+    public RecruitRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public Page<Recruit> getMyRecruits(Long employerId, RecruitType recruitType, RecruitPublishStatus recruitPublishStatus, boolean excludeExpired, Pageable pageable) {
+        List<Recruit> content = queryFactory
+                .selectFrom(recruit)
+                .innerJoin(recruit.employer).fetchJoin()
+                .where(
+                        recruit.employer.id.eq(employerId),
+                        recruit.recruitPublishStatus.eq(recruitPublishStatus),
+                        excludeExpiredEq(excludeExpired),
+                        recruitTypeEq(recruitType)
+                )
+                .orderBy(recruit.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(recruit.count())
+                .from(recruit)
+                .where(
+                        recruit.employer.id.eq(employerId),
+                        recruit.recruitPublishStatus.eq(recruitPublishStatus),
+                        excludeExpiredEq(excludeExpired),
+                        recruitTypeEq(recruitType)
+                );
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    private BooleanExpression excludeExpiredEq(boolean excludeExpired) {
+        return excludeExpired ? recruit.recruitEndDate.after(LocalDate.now().minusDays(1)) : null;
+    }
+
+    private BooleanExpression recruitTypeEq(RecruitType recruitType) {
+        return recruitType==null?null:recruit.recruitType.eq(recruitType);
+    }
+
+
+
+}

--- a/src/main/java/com/core/foreign/api/recruit/repository/RecruitRepositoryQueryDSL.java
+++ b/src/main/java/com/core/foreign/api/recruit/repository/RecruitRepositoryQueryDSL.java
@@ -1,0 +1,12 @@
+package com.core.foreign.api.recruit.repository;
+
+import com.core.foreign.api.recruit.entity.Recruit;
+import com.core.foreign.api.recruit.entity.RecruitPublishStatus;
+import com.core.foreign.api.recruit.entity.RecruitType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface RecruitRepositoryQueryDSL {
+    Page<Recruit> getMyRecruits(Long employerId, RecruitType recruitType, RecruitPublishStatus recruitPublishStatus,
+                                boolean excludeExpired , Pageable pageable);
+}

--- a/src/main/java/com/core/foreign/api/recruit/service/RecruitService.java
+++ b/src/main/java/com/core/foreign/api/recruit/service/RecruitService.java
@@ -637,17 +637,23 @@ public class RecruitService {
     }
 
 
-    /**
-     * @implNote
-     * 상단 노출 필터링은 나중에
-     */
-    public Page<MyRecruitResponseDTO> getMyRecruits(Long employerId, Integer page, RecruitType recruitType){
-        Pageable pageable = PageRequest.of(page, 5, Sort.by(Sort.Direction.DESC, "id"));
-        Page<MyRecruitResponseDTO> map = recruitRepository.findByEmployerIdAndRecruitType(employerId, recruitType, pageable)
+    public Page<MyRecruitResponseDTO> getMyRecruits(Long employerId, Integer page, Integer size, RecruitType recruitType, boolean excludeExpired){
+        Pageable pageable= PageRequest.of(page, size);
+
+        Page<MyRecruitResponseDTO> response = recruitRepository.getMyRecruits(employerId, recruitType, RecruitPublishStatus.PUBLISHED, excludeExpired, pageable)
                 .map(MyRecruitResponseDTO::from);
 
-        return map;
 
+        return response;
+    }
+
+    public Page<MyDraftRecruitResponseDTO> getMyDraftRecruits(Long employerId, Integer page, Integer size){
+        Pageable pageable= PageRequest.of(page, size);
+
+        Page<MyDraftRecruitResponseDTO> response = recruitRepository.getMyRecruits(employerId, null , RecruitPublishStatus.DRAFT, false, pageable)
+                .map(MyDraftRecruitResponseDTO::from);
+
+        return response;
     }
 
     public Page<RecruitmentApplyStatusDTO> getRecruitmentApplyStatus(Long employerId, Integer page){


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #73 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
고용인 마이페이지 부분 임시 저장한 공고와 내가 등록한 공고 조회 수정.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
-현재 임시 공고는 하나만 등록이 가능하여 직접 DB를 수정하여 테스트했습니다.
- 따라서 임시 공고 등록 부분 수정 후 다시 테스트할 예정입니다.
- 내 공고 조회 시 workDuration, workDays,workTime 부분은 임시로 null 로 하였습니다.
- 이 부분은 Recruit entity의 수정이 필요하다 생각되어 추후 진행할 예정입니다.


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
![내 공고 조회 성공](https://github.com/user-attachments/assets/363cde86-263e-4547-b02d-5fa5ea01a788)
![임시 공고 조회](https://github.com/user-attachments/assets/168f99c2-3d2f-486e-b3bc-1a76a65385e5)

