### PR TITLE
[FEAT] 알바 후기 댓글 수정, 삭제 기능 구현

### DIFF
--- a/src/main/java/com/core/foreign/api/albareview/controller/AlbaReviewCommentController.java
+++ b/src/main/java/com/core/foreign/api/albareview/controller/AlbaReviewCommentController.java
@@ -2,6 +2,7 @@ package com.core.foreign.api.albareview.controller;
 
 import com.core.foreign.api.albareview.dto.AlbaReviewCommentCreateDTO;
 import com.core.foreign.api.albareview.dto.AlbaReviewCommentResponseDTO;
+import com.core.foreign.api.albareview.dto.AlbaReviewCommentUpdateDTO;
 import com.core.foreign.api.albareview.service.AlbaReviewCommentService;
 import com.core.foreign.common.SecurityMember;
 import com.core.foreign.common.response.ApiResponse;
@@ -42,7 +43,9 @@ public class AlbaReviewCommentController {
 
     @Operation(
             summary = "알바 후기 댓글 조회 API",
-            description = "리뷰 ID에 해당하는 댓글들을 최신순(생성일 내림차순)으로 반환합니다."
+            description = "리뷰 ID에 해당하는 댓글들을 최신순(생성일 내림차순)으로 반환합니다. <br>" +
+                    "<p>" +
+                    "내 댓글 여부 : 'mine : true'"
     )
     @io.swagger.v3.oas.annotations.responses.ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "알바 후기 댓글 조회 성공"),
@@ -50,9 +53,46 @@ public class AlbaReviewCommentController {
     })
     @GetMapping("/comment")
     public ResponseEntity<ApiResponse<List<AlbaReviewCommentResponseDTO>>> getCommentsByReviewId(
+            @AuthenticationPrincipal SecurityMember securityMember,
             @RequestParam Long reviewId) {
 
-        List<AlbaReviewCommentResponseDTO> comments = albaReviewCommentService.getCommentsByReviewId(reviewId);
+        Long memberId = (securityMember != null) ? securityMember.getId() : null;
+        List<AlbaReviewCommentResponseDTO> comments = albaReviewCommentService.getCommentsByReviewId(reviewId, memberId);
         return ApiResponse.success(SuccessStatus.SEND_ALBA_REVIEW_COMMENT_SUCCESS, comments);
+    }
+
+    @Operation(
+            summary = "알바 후기 댓글 수정 API",
+            description = "댓글 작성자만 댓글을 수정할 수 있습니다."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "알바 후기 댓글 수정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다.")
+    })
+    @PutMapping("/comment/{commentId}")
+    public ResponseEntity<ApiResponse<Void>> updateAlbaReviewComment(
+            @AuthenticationPrincipal SecurityMember securityMember,
+            @PathVariable Long commentId,
+            @RequestBody AlbaReviewCommentUpdateDTO albaReviewCommentUpdateDTO) {
+
+        albaReviewCommentService.updateAlbaReviewComment(commentId, albaReviewCommentUpdateDTO, securityMember.getId());
+        return ApiResponse.success_only(SuccessStatus.ALBA_REVIEW_COMMENT_UPDATE_SUCCESS);
+    }
+
+    @Operation(
+            summary = "알바 후기 댓글 삭제 API",
+            description = "댓글 작성자만 댓글을 삭제할 수 있습니다."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "알바 후기 댓글 삭제 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다.")
+    })
+    @DeleteMapping("/comment/{commentId}")
+    public ResponseEntity<ApiResponse<Void>> deleteAlbaReviewComment(
+            @AuthenticationPrincipal SecurityMember securityMember,
+            @PathVariable Long commentId) {
+
+        albaReviewCommentService.deleteAlbaReviewComment(commentId, securityMember.getId());
+        return ApiResponse.success_only(SuccessStatus.ALBA_REVIEW_COMMENT_DELETE_SUCCESS);
     }
 }

--- a/src/main/java/com/core/foreign/api/albareview/dto/AlbaReviewCommentResponseDTO.java
+++ b/src/main/java/com/core/foreign/api/albareview/dto/AlbaReviewCommentResponseDTO.java
@@ -4,8 +4,10 @@ import lombok.Data;
 
 @Data
 public class AlbaReviewCommentResponseDTO {
+    private Long id;           // 댓글 ID
     private String userId;     // 댓글 작성자 ID
     private String comment;  // 댓글 내용
     private String createdAt; // 작성일 (yyyy.MM.dd)
     private Long parentId; // 부모 댓글 ID
+    private boolean isMine;  // 현재 로그인한 사용자가 작성한 댓글인지 여부
 }

--- a/src/main/java/com/core/foreign/api/albareview/dto/AlbaReviewCommentUpdateDTO.java
+++ b/src/main/java/com/core/foreign/api/albareview/dto/AlbaReviewCommentUpdateDTO.java
@@ -1,0 +1,8 @@
+package com.core.foreign.api.albareview.dto;
+
+import lombok.Data;
+
+@Data
+public class AlbaReviewCommentUpdateDTO {
+    private String content; // 수정할 댓글 내용
+}

--- a/src/main/java/com/core/foreign/api/albareview/repository/AlbaReviewRepository.java
+++ b/src/main/java/com/core/foreign/api/albareview/repository/AlbaReviewRepository.java
@@ -10,7 +10,19 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface AlbaReviewRepository extends JpaRepository<AlbaReview, Long> {
 
+    // 조회 수 증가
     @Modifying
     @Query("update AlbaReview a set a.readCount = a.readCount + 1 where a.id = :reviewId")
     void incrementReadCount(@Param("reviewId") Long reviewId);
+
+    // 댓글 수 증가
+    @Modifying
+    @Query("update AlbaReview a set a.commentCount = a.commentCount + 1 where a.id = :reviewId")
+    void incrementCommentCount(@Param("reviewId") Long reviewId);
+
+    // 댓글 수 감소
+    @Modifying
+    @Query("update AlbaReview a set a.commentCount = case when a.commentCount > 0 then a.commentCount - 1 else 0 end where a.id = :reviewId")
+    void decrementCommentCount(@Param("reviewId") Long reviewId);
+
 }

--- a/src/main/java/com/core/foreign/common/response/ErrorStatus.java
+++ b/src/main/java/com/core/foreign/common/response/ErrorStatus.java
@@ -58,10 +58,7 @@ public enum ErrorStatus {
     CONTRACT_TYPE_SELECTION_REQUIRED_EXCEPTION(HttpStatus.BAD_REQUEST, "계약서 형태를 선택하세요."),
     EMPLOYEE_CANNOT_SELECT_CONTRACT_TYPE_EXCEPTION(HttpStatus.BAD_REQUEST, "피고용인은 계약서 형태를 선택할 수 없습니다."),
     FILE_UPLOAD_NOT_ALLOWED_FOR_NON_FILE_CONTRACT_EXCEPTION(HttpStatus.BAD_REQUEST, "파일 업로드 계약서가 아닌 경우 업로드 할 수 없습니다."),
-
-
-
-
+    ONLY_MODIFY_WRITER_USER_EXCEPTION(HttpStatus.BAD_REQUEST,"수정 권한이 없습니다."),
 
     /**
      * 401 UNAUTHORIZED
@@ -87,6 +84,7 @@ public enum ErrorStatus {
     RESUME_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 이력서를 찾을 수 없습니다."),
     ALBAREVIEW_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND,"알바 후기를 찾을 수 없습니다."),
     PARENT_COMMENT_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND,"부모 댓글을 찾을 수 없습니다."),
+    COMMENT_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND,"부모 댓글을 찾을 수 없습니다."),
     PORTFOLIO_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 포트폴리오를 찾을 수 없습니다."),
     CONTRACT_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "계약서를 찾을 수 없습니다."),
 

--- a/src/main/java/com/core/foreign/common/response/SuccessStatus.java
+++ b/src/main/java/com/core/foreign/common/response/SuccessStatus.java
@@ -67,8 +67,8 @@ public enum SuccessStatus {
     INCOMPLETE_CONTRACT_VIEW_SUCCESS(HttpStatus.OK, "미완료된 계약서 조회 성공"),
     CONTRACT_TYPE_SELECTION_SUCCESS(HttpStatus.OK, "계약서 형태 선택 성공"),
     CONTRACT_UPLOAD_SUCCESS(HttpStatus.OK, "계약서 업로드 성공"),
-
-
+    ALBA_REVIEW_COMMENT_UPDATE_SUCCESS(HttpStatus.OK,"알바 후기 댓글 수정 성공"),
+    ALBA_REVIEW_COMMENT_DELETE_SUCCESS(HttpStatus.OK,"알바 후기 댓글 삭제 성공"),
 
     /**
      * 201


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #85

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 알바 후기 댓글 수정, 삭제 기능을 구현하였습니다.
- 댓글 생성, 삭제로 인한 알바 후기 조회 수 관리 로직을 구현하였습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 회원탈퇴, 공고 삭제, 알바 후기, 알바 후기 댓글 등등 현재 MVP 단계에서는 하드삭제(즉시 삭제)로 구현되어있지만 법률적인 문제 등으로 인해 리팩토링 단계에서 소프트삭제(실질적인 삭제가 아닌 필드를 통한 논리적 삭제)로 변경해야합니다. 또한 추후 IP주소를 수집해야하는 로직도 추가해야합니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
![image](https://github.com/user-attachments/assets/6088c89e-3953-4b89-a8d9-333e67cae193)
