### PR TITLE
[FEAT] 서버 오류, 알림 슬랙 전송 기능 구현

### DIFF
--- a/src/main/java/com/core/foreign/common/advice/ControllerExceptionAdvice.java
+++ b/src/main/java/com/core/foreign/common/advice/ControllerExceptionAdvice.java
@@ -1,8 +1,13 @@
 package com.core.foreign.common.advice;
 
+import com.core.foreign.common.exception.BadRequestException;
 import com.core.foreign.common.exception.BaseException;
+import com.core.foreign.common.exception.NotFoundException;
 import com.core.foreign.common.response.ApiResponse;
 import com.core.foreign.common.response.ErrorStatus;
+import com.core.foreign.common.slack.SlackNotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -13,15 +18,31 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.Objects;
 
+@Slf4j
 @RestControllerAdvice
+@RequiredArgsConstructor
 public class ControllerExceptionAdvice {
 
+    private final SlackNotificationService slackNotificationService;
+
+    /**
+     * BaseException 계열 처리
+     * - BadRequestException, NotFoundException을 제외한 예외에 대해서만 슬랙 알림 전송
+     */
     @ExceptionHandler(BaseException.class)
     public ResponseEntity<ApiResponse> handleGlobalException(BaseException ex) {
+        // BadRequest, NotFound가 아닌 BaseException 예외라면 슬랙 알림
+        if (!(ex instanceof BadRequestException) && !(ex instanceof NotFoundException)) {
+            slackNotificationService.sendServerErrorMessage(ex.getMessage());
+        }
+
         return ResponseEntity.status(ex.getStatusCode())
                 .body(ApiResponse.fail(ex.getStatusCode(), ex.getResponseMessage()));
     }
 
+    /**
+     * 필수 Request Parameter가 누락되었을 경우
+     */
     @ExceptionHandler(MissingServletRequestParameterException.class)
     public ResponseEntity<ApiResponse> handleMissingParameter(MissingServletRequestParameterException ex) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
@@ -29,17 +50,39 @@ public class ControllerExceptionAdvice {
                         ErrorStatus.VALIDATION_REQUEST_MISSING_EXCEPTION.getMessage()));
     }
 
+    /**
+     * 잘못된 인자가 전달되었을 경우
+     */
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ApiResponse>  handleIllegalArgument(IllegalArgumentException ex) {
+    public ResponseEntity<ApiResponse> handleIllegalArgument(IllegalArgumentException ex) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ApiResponse.fail(HttpStatus.BAD_REQUEST.value(), ex.getMessage()));
     }
 
+    /**
+     * @Valid 검증 실패 시 발생
+     */
     @ExceptionHandler(MethodArgumentNotValidException.class)
     protected ResponseEntity<ApiResponse> handleMethodArgumentNotValidException(final MethodArgumentNotValidException e) {
         FieldError fieldError = Objects.requireNonNull(e.getFieldError());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.fail(HttpStatus.BAD_REQUEST.value(),String.format("%s. (%s)", fieldError.getDefaultMessage(), fieldError.getField())));
+                .body(ApiResponse.fail(HttpStatus.BAD_REQUEST.value(),
+                        String.format("%s. (%s)", fieldError.getDefaultMessage(), fieldError.getField())));
+    }
+
+    /**
+     * 그 외 모든 알 수 없는 예외 처리
+     * - BaseException을 상속받지 않은 RuntimeException, Exception 등에 대한 처리
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse> handleAnyException(Exception e) {
+        // 여기서는 BadRequest, NotFound 예외가 아닌 모든 예외이므로 Slack 알림 전송
+        slackNotificationService.sendServerErrorMessage(e.getMessage());
+
+        log.error("[handleAnyException] 알 수 없는 오류 발생", e);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.fail(HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                        "알 수 없는 오류 발생"));
     }
 
 }

--- a/src/main/java/com/core/foreign/common/slack/SlackNotificationService.java
+++ b/src/main/java/com/core/foreign/common/slack/SlackNotificationService.java
@@ -1,0 +1,56 @@
+package com.core.foreign.common.slack;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SlackNotificationService {
+
+    @Value("${slack.webhook.url}")
+    private String slackWebhookUrl;
+
+    /**
+     * 슬랙에 간단한 텍스트 메시지를 보내는 메서드
+     */
+    public void sendSlackMessage(String message) {
+        try {
+            RestTemplate restTemplate = new RestTemplate(getClientHttpRequestFactory());
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+
+            String payload = "{\"text\": \"" + message + "\"}";
+
+            HttpEntity<String> entity = new HttpEntity<>(payload, headers);
+            restTemplate.postForObject(slackWebhookUrl, entity, String.class);
+
+        } catch (Exception e) {
+            // Slack 전송 중 예외가 발생해도 서비스 로직에 영향 주지 않도록 로그만 남기고 처리
+            log.error("슬랙 메시지 전송 실패: {}", e.getMessage());
+        }
+    }
+
+    private SimpleClientHttpRequestFactory getClientHttpRequestFactory() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(3000);
+        factory.setReadTimeout(3000);
+        return factory;
+    }
+
+    /**
+     * 서버 오류 알림
+     * 예) "[오류] 에러 내용"
+     */
+    public void sendServerErrorMessage(String errorMessage) {
+        String message = String.format("[오류] %s", errorMessage);
+        sendSlackMessage(message);
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #91

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 서버 오류, 알림 내용을 슬랙으로 전송하는 기능을 구현하였습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- BadRequest(400), NotFound(404)는 발송 대상 제외입니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
![image](https://github.com/user-attachments/assets/8f4372f1-f436-4404-8bc8-6eeb0f600150)
