### PR TITLE
[FEAT] 프리미엄, 일반 공고 상단 점프 기능 구현

### DIFF
--- a/src/main/java/com/core/foreign/api/recruit/controller/RecruitController.java
+++ b/src/main/java/com/core/foreign/api/recruit/controller/RecruitController.java
@@ -494,8 +494,8 @@ public class RecruitController {
     public ResponseEntity<ApiResponse<Void>> applyGeneralRecruit(@AuthenticationPrincipal SecurityMember securityMember,
                                                                        @PathVariable("recruit-id") Long recruitId,
                                                                        @RequestBody GeneralResumeRequestDTO dto) {
-        resumeService.applyResume(securityMember.getId(), recruitId,dto);
 
+        resumeService.applyResume(securityMember.getId(), recruitId,dto);
         return ApiResponse.success_only(SuccessStatus.APPLY_RECRUIT_ARTICLE_SUCCESS);
     }
 
@@ -509,8 +509,8 @@ public class RecruitController {
     public ResponseEntity<ApiResponse<Void>> applyPremiumResume(@AuthenticationPrincipal SecurityMember securityMember,
                                                                  @PathVariable("recruit-id") Long recruitId,
                                                                  @RequestBody PremiumResumeRequestDTO dto) {
-        resumeService.applyPremiumResume(securityMember.getId(), recruitId,dto);
 
+        resumeService.applyPremiumResume(securityMember.getId(), recruitId,dto);
         return ApiResponse.success_only(SuccessStatus.APPLY_RECRUIT_ARTICLE_SUCCESS);
     }
 
@@ -563,7 +563,6 @@ public class RecruitController {
                     "friendlyBoss: 사장님이 친절해요 (개수)<br>" +
                     "fairWorkload: 업무 강도가 적당해요 (개수)<br>" +
                     "joinCount: 평가에 참여수"
-
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "공고 상세 조회 성공"),
@@ -591,7 +590,6 @@ public class RecruitController {
         return ApiResponse.success(SuccessStatus.SEND_RECRUITMENT_APPLICATION_STATUS_SUCCESS, recruitmentApplyStatus);
     }
 
-
     @Operation(summary = "지원자 이력서 보기 API",
             description = "지원자의 이력서를 조회합니다.<br>"
     )
@@ -617,8 +615,6 @@ public class RecruitController {
                     "recruitmentStatus: 모집상태<br>" +
                     "evaluationStatus: 평가상태<br>" +
                     "contractStatus: 계약서상태<br>"
-
-
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "공고에 지원한 피고용인들 조회 성공"),
@@ -631,7 +627,6 @@ public class RecruitController {
                                                                                                                   @RequestParam("recruitmentStatus") RecruitmentStatus recruitmentStatus,
                                                                                                                   @RequestParam(value = "contractStatus", required = false) ContractStatus contractStatus,
                                                                                                                   @RequestParam("page") Integer page) {
-
 
         Page<ApplicationResumePreviewResponseDTO> responseDTOS = resumeService.searchApplicationResume(recruitId, keyword, recruitmentStatus, contractStatus, page);
         return ApiResponse.success(SuccessStatus.SEND_APPLICANTS_FOR_RECRUIT_SUCCESS, responseDTOS);
@@ -667,7 +662,6 @@ public class RecruitController {
         return ApiResponse.success_only(SuccessStatus.UPDATE_RECRUITMENT_STATUS_SUCCESS);
     }
 
-
     @Operation(summary = "피고용인 작성한 이력서 리스트 조회 API",
             description = "피고용인 작성한 이력서 리스트 조회.<br>"
     )
@@ -678,10 +672,9 @@ public class RecruitController {
     @GetMapping(value = "/my-resumes")
     public ResponseEntity<ApiResponse<Page<EmployeeApplicationStatusResponseDTO>>> getMyResumes(@AuthenticationPrincipal SecurityMember securityMember,
                                                            @RequestParam("page") Integer page) {
+
         Page<EmployeeApplicationStatusResponseDTO> response = resumeService.getMyResumes(securityMember.getId(), page);
-
         return ApiResponse.success(SuccessStatus.SEND_MY_RESUME_SUCCESS, response);
-
     }
 
     @Operation(summary = "피고용인 자신이 작성한 이력서 삭제. API",
@@ -694,10 +687,9 @@ public class RecruitController {
     @DeleteMapping(value = "/my-resumes/{resume-id}/remove")
     public ResponseEntity<ApiResponse<Void>> removeMyResume(@AuthenticationPrincipal SecurityMember securityMember,
                                                             @PathVariable("resume-id") Long resumeId) {
+
         resumeService.removeMyResume(securityMember.getId(), resumeId);
-
         return ApiResponse.success_only(SuccessStatus.DELETE_MY_RESUME_SUCCESS);
-
     }
 
     @Operation(summary = "공고 찜하기 상태 변경. API",
@@ -710,10 +702,9 @@ public class RecruitController {
     @PatchMapping(value = "/{recruit-id}/bookmark")
     public ResponseEntity<ApiResponse<Boolean>> flipRecruitBookmark(@AuthenticationPrincipal SecurityMember securityMember,
                                                                  @PathVariable("recruit-id") Long recruitId) {
+
         boolean b = recruitService.flipRecruitBookmark(securityMember.getId(), recruitId);
-
         return ApiResponse.success(SuccessStatus.UPDATE_RECRUIT_BOOKMARK_STATUS_SUCCESS, b);
-
     }
 
     @Operation(summary = "찜한 공고 조회. API",
@@ -726,10 +717,9 @@ public class RecruitController {
     @GetMapping(value = "/bookmarks")
     public ResponseEntity<ApiResponse<Page<RecruitBookmarkResponseDTO>>> getRecruitBookmarks(@AuthenticationPrincipal SecurityMember securityMember,
                                                                  @RequestParam(value = "page", defaultValue = "0") Integer  page) {
+
         Page<RecruitBookmarkResponseDTO> response = recruitService.getMyRecruitBookmark(securityMember.getId(), page);
-
         return ApiResponse.success(SuccessStatus.SEND_BOOKMARKED_RECRUITS_SUCCESS, response);
-
     }
 
     @Operation(summary = "고용인의 내 공고 조회 API",
@@ -754,10 +744,9 @@ public class RecruitController {
                                                                          @RequestParam("size")Integer size,
                                                                          @RequestParam(value = "recruitType", required = false)RecruitType recruitType,
                                                                          @RequestParam(value = "excludeExpired", defaultValue = "false")boolean excludeExpired) {
+
         Page<MyRecruitResponseDTO> recruits = recruitService.getMyRecruits(securityMember.getId(), page, size, recruitType, excludeExpired);
-
         return ApiResponse.success(SuccessStatus.SEND_EMPLOYER_RECRUIT_LIST_SUCCESS, recruits);
-
     }
 
     @Operation(summary = "고용인 내 임시 공고 공고 조회 API",
@@ -771,12 +760,10 @@ public class RecruitController {
     public ResponseEntity<ApiResponse<Page<MyDraftRecruitResponseDTO>>> getMyDraftRecruits(@AuthenticationPrincipal SecurityMember securityMember,
                                                                                  @RequestParam(value = "page", defaultValue = "0") Integer  page,
                                                                                  @RequestParam("size")Integer size) {
+
         Page<MyDraftRecruitResponseDTO> recruits = recruitService.getMyDraftRecruits(securityMember.getId(), page, size);
-
         return ApiResponse.success(SuccessStatus.SEND_EMPLOYER_RECRUIT_LIST_SUCCESS, recruits);
-
     }
-
 
     @Operation(summary = "프리미엄 공고의 포트폴리오 조회. API",
             description = "프리미엄 공고의 포트폴리오 조회.<br>"
@@ -790,9 +777,85 @@ public class RecruitController {
                                                                                  @PathVariable("recruit-id") Long recruitId) {
 
         List<PortfolioResponseDTO> portfolios = recruitService.getPortfolios(recruitId);
-
         return ApiResponse.success(SuccessStatus.PORTFOLIO_VIEW_SUCCESS, portfolios);
+    }
 
+    @Operation(summary = "프리미엄 공고 상단 점프 API",
+            description = "프리미엄 공고를 상단으로 올립니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "공고 상단 점프 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+    })
+    @PatchMapping("/premium/{recruitId}/top-jump")
+    public ResponseEntity<ApiResponse<Void>> topJumpPremiumRecruit(
+            @AuthenticationPrincipal SecurityMember securityMember,
+            @PathVariable Long recruitId
+    ) {
+        recruitService.topJumpPremiumRecruit(recruitId, securityMember.getId());
+        return ApiResponse.success_only(SuccessStatus.UPDATE_TOP_JUMP_SUCCESS);
+    }
+
+    @Operation(summary = "일반 공고 상단 점프 API",
+            description = "일반 공고를 상단으로 올립니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "공고 상단 점프 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+    })
+    @PatchMapping("/general/{recruitId}/top-jump")
+    public ResponseEntity<ApiResponse<Void>> topJumpGeneralRecruit(
+            @AuthenticationPrincipal SecurityMember securityMember,
+            @PathVariable Long recruitId
+    ) {
+        recruitService.topJumpGeneralRecruit(recruitId, securityMember.getId());
+        return ApiResponse.success_only(SuccessStatus.UPDATE_TOP_JUMP_SUCCESS);
+    }
+
+    @Operation(summary = "상단 점프 잔여 횟수 조회 API",
+            description = "현재 사용자가 보유한 프리미엄/일반 상단 점프 횟수를 반환합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "상단 점프 잔여 횟수 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다.")
+    })
+    @GetMapping("/top-jump-count")
+    public ResponseEntity<ApiResponse<TopJumpCountResponseDTO>> getTopJumpCounts(
+            @AuthenticationPrincipal SecurityMember securityMember
+    ) {
+        TopJumpCountResponseDTO topJumpCountResponseDTO = recruitService.getTopJumpCounts(securityMember.getId());
+        return ApiResponse.success(SuccessStatus.SEND_TOP_JUMP_COUNT_SUCCESS, topJumpCountResponseDTO);
+    }
+
+    @Operation(summary = "프리미엄 공고 상단 점프 목록 조회 API",
+            description = "프리미엄 공고 중 상단 점프를 한 공고들을 최신순으로 반환합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "프리미엄 공고 목록 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다.")
+    })
+    @GetMapping("/premium/jump")
+    public ResponseEntity<ApiResponse<PageResponseDTO<RecruitListResponseDTO>>> getPremiumJumpedRecruits(
+            @RequestParam(required = false, defaultValue = "0") Integer page,
+            @RequestParam(required = false, defaultValue = "10") Integer size
+    ) {
+        Page<RecruitListResponseDTO> recruitPage = recruitService.getRecruitsOrderedByJumpDate(RecruitType.PREMIUM, page, size);
+        PageResponseDTO<RecruitListResponseDTO> response = PageResponseDTO.of(recruitPage);
+        return ApiResponse.success(SuccessStatus.SEND_RECRUIT_ALL_LIST_SUCCESS, response);
+    }
+
+    @Operation(summary = "일반 공고 상단 점프 목록 조회 API",
+            description = "일반 공고 중 상단 점프를 한 공고들을 최신순으로 반환합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "일반 공고 목록 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다.")
+    })
+    @GetMapping("/general/jump")
+    public ResponseEntity<ApiResponse<PageResponseDTO<RecruitListResponseDTO>>> getGeneralJumpedRecruits(
+            @RequestParam(required = false, defaultValue = "0") Integer page,
+            @RequestParam(required = false, defaultValue = "10") Integer size
+    ) {
+        Page<RecruitListResponseDTO> recruitPage = recruitService.getRecruitsOrderedByJumpDate(RecruitType.GENERAL, page, size);
+        PageResponseDTO<RecruitListResponseDTO> response = PageResponseDTO.of(recruitPage);
+        return ApiResponse.success(SuccessStatus.SEND_RECRUIT_ALL_LIST_SUCCESS, response);
     }
 
 }

--- a/src/main/java/com/core/foreign/api/recruit/dto/TopJumpCountResponseDTO.java
+++ b/src/main/java/com/core/foreign/api/recruit/dto/TopJumpCountResponseDTO.java
@@ -1,0 +1,13 @@
+package com.core.foreign.api.recruit.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TopJumpCountResponseDTO {
+    private int premiumJumpCount;
+    private int normalJumpCount;
+}

--- a/src/main/java/com/core/foreign/api/recruit/entity/GeneralRecruit.java
+++ b/src/main/java/com/core/foreign/api/recruit/entity/GeneralRecruit.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Table;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
@@ -44,6 +45,7 @@ public class GeneralRecruit extends Recruit {
             String salaryOther,
             Set<ApplyMethod> applicationMethods,
             String posterImageUrl,
+            LocalDateTime jumpDate,
             RecruitPublishStatus recruitPublishStatus) {
         super(
                 title,
@@ -70,6 +72,7 @@ public class GeneralRecruit extends Recruit {
                 applicationMethods,
                 RecruitType.GENERAL,
                 posterImageUrl,
+                jumpDate,
                 recruitPublishStatus
         );
     }

--- a/src/main/java/com/core/foreign/api/recruit/entity/PremiumManage.java
+++ b/src/main/java/com/core/foreign/api/recruit/entity/PremiumManage.java
@@ -29,24 +29,7 @@ public class PremiumManage {
     public PremiumManage(Employer employer) {
         this.employer = employer;
         this.premiumCount = 0;
-        this.premiumJumpCount = 0;
-        this.normalJumpCount = 0;
-    }
-
-    // 프리미엄 공고 등록 횟수 증가
-    public PremiumManage increasePremiumCount() {
-        return this.toBuilder()
-                .premiumCount(this.premiumCount + 1)
-                .build();
-    }
-
-    // 프리미엄 공고 등록 횟수 감소
-    public PremiumManage decreasePremiumCount() {
-        if (this.premiumCount == 0) {
-            throw new BadRequestException(ErrorStatus.LEAK_PREMIUM_RECRUIT_PUBLISH_COUNT_EXCEPTION.getMessage());
-        }
-        return this.toBuilder()
-                .premiumCount(this.premiumCount - 1)
-                .build();
+        this.premiumJumpCount = 5;
+        this.normalJumpCount = 5;
     }
 }

--- a/src/main/java/com/core/foreign/api/recruit/entity/PremiumRecruit.java
+++ b/src/main/java/com/core/foreign/api/recruit/entity/PremiumRecruit.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -49,6 +50,7 @@ public class PremiumRecruit extends Recruit {
             String salaryOther,
             Set<ApplyMethod> applicationMethods,
             String posterImageUrl,
+            LocalDateTime jumpDate,
             RecruitPublishStatus recruitPublishStatus) {
         super(
                 title,
@@ -75,6 +77,7 @@ public class PremiumRecruit extends Recruit {
                 applicationMethods,
                 RecruitType.PREMIUM,
                 posterImageUrl,
+                jumpDate,
                 recruitPublishStatus
         );
     }

--- a/src/main/java/com/core/foreign/api/recruit/entity/Recruit.java
+++ b/src/main/java/com/core/foreign/api/recruit/entity/Recruit.java
@@ -8,6 +8,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
@@ -93,6 +94,12 @@ public abstract class Recruit extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     protected RecruitPublishStatus recruitPublishStatus; // 공고 상태 (PUBLISHED, DRAFT)
 
+    protected LocalDateTime jumpDate;
+
+    public void jumpNow() {
+        this.jumpDate = LocalDateTime.now();
+    }
+
     protected Recruit(String title,
                       Member employer,
                       Address address,
@@ -117,6 +124,7 @@ public abstract class Recruit extends BaseTimeEntity {
                       Set<ApplyMethod> applicationMethods,
                       RecruitType recruitType,
                       String posterImageUrl,
+                      LocalDateTime jumpDate,
                       RecruitPublishStatus recruitPublishStatus) {
         this.title = title;
         this.employer = employer;
@@ -143,6 +151,7 @@ public abstract class Recruit extends BaseTimeEntity {
         this.recruitType = recruitType;
         this.posterImageUrl = posterImageUrl;
         this.recruitPublishStatus = recruitPublishStatus;
+        this.jumpDate = jumpDate;
     }
 
 

--- a/src/main/java/com/core/foreign/api/recruit/repository/PremiumManageRepository.java
+++ b/src/main/java/com/core/foreign/api/recruit/repository/PremiumManageRepository.java
@@ -2,11 +2,51 @@ package com.core.foreign.api.recruit.repository;
 
 import com.core.foreign.api.recruit.entity.PremiumManage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
 @Repository
 public interface PremiumManageRepository extends JpaRepository<PremiumManage, Long> {
     Optional<PremiumManage> findByEmployerId(Long employerId);
+
+    // 프리미엄 공고 등록 횟수 증가
+    @Transactional
+    @Modifying
+    @Query("UPDATE PremiumManage pm SET pm.premiumCount = pm.premiumCount + 1 WHERE pm.employer.id = :employerId")
+    int increasePremiumCount(@Param("employerId") Long employerId);
+
+    // 프리미엄 공고 등록 횟수 감소
+    @Transactional
+    @Modifying
+    @Query("UPDATE PremiumManage pm SET pm.premiumCount = pm.premiumCount - 1 WHERE pm.employer.id = :employerId AND pm.premiumCount > 0")
+    int decreasePremiumCount(@Param("employerId") Long employerId);
+
+    // 프리미엄 상단점프 카운트 증가
+    @Transactional
+    @Modifying
+    @Query("UPDATE PremiumManage pm SET pm.premiumJumpCount = pm.premiumJumpCount + 3 WHERE pm.employer.id = :employerId")
+    int increasePremiumJumpCount(@Param("employerId") Long employerId);
+
+    // 일반 상단점프 카운트 증가
+    @Transactional
+    @Modifying
+    @Query("UPDATE PremiumManage pm SET pm.normalJumpCount = pm.normalJumpCount + 3 WHERE pm.employer.id = :employerId")
+    int increaseNormalJumpCount(@Param("employerId") Long employerId);
+
+    // 프리미엄 상단점프 카운트 감소
+    @Transactional
+    @Modifying
+    @Query("UPDATE PremiumManage pm SET pm.premiumJumpCount = pm.premiumJumpCount - 1 WHERE pm.employer.id = :employerId AND pm.premiumJumpCount > 0")
+    int decreasePremiumJumpCount(@Param("employerId") Long employerId);
+
+    // 일반 상단점프 카운트 감소
+    @Transactional
+    @Modifying
+    @Query("UPDATE PremiumManage pm SET pm.normalJumpCount = pm.normalJumpCount - 1 WHERE pm.employer.id = :employerId AND pm.normalJumpCount > 0")
+    int decreaseNormalJumpCount(@Param("employerId") Long employerId);
 }

--- a/src/main/java/com/core/foreign/api/recruit/repository/RecruitRepository.java
+++ b/src/main/java/com/core/foreign/api/recruit/repository/RecruitRepository.java
@@ -43,17 +43,16 @@ public interface RecruitRepository
             "where r.id = :recruitId")
     Optional<Recruit> findByIdFetchJoin(@Param("recruitId") Long recruitId);
 
-
-
     @Query("select r from Recruit r" +
             " where r.employer.id=:employerId and r.recruitType=:recruitType and r.recruitPublishStatus='PUBLISHED'")
     Page<Recruit> findByEmployerIdAndRecruitType(@Param("employerId")Long employerId, @Param("recruitType")RecruitType recruitType, Pageable pageable);
-
 
     @Query("select r from Recruit r" +
             " where r.employer.id=:employerId ")
     Page<Recruit> findByEmployerId(Long employerId, Pageable pageable);
 
-
+    // 해당 공고 유형(recruitType)이고 jumpDate가 설정된 공고를 jumpDate 내림차순으로 조회
+    @Query("SELECT r FROM Recruit r WHERE r.recruitType = :recruitType AND r.jumpDate IS NOT NULL ORDER BY r.jumpDate DESC")
+    Page<Recruit> findByRecruitTypeAndJumpDateIsNotNullOrderByJumpDateDesc(@Param("recruitType") RecruitType recruitType, Pageable pageable);
 
 }

--- a/src/main/java/com/core/foreign/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/core/foreign/common/config/security/SecurityConfig.java
@@ -71,8 +71,8 @@ public class SecurityConfig {
                                 "/api/v1/member/verification-phone-code", "/api/v1/member/find-user-id", "/api/v1/member/employer/company-validate"
                         ).permitAll() // 회원가입, 로그인, 토큰 재발급, 이메일 인증, 사업자등록 번호 인증 허가
                         .requestMatchers(
-                                "/api/v1/recruit/search","/api/v1/recruit/view"
-                        ).permitAll() // 공고 전체 조회, 공고 상세 조회 인증 허가
+                                "/api/v1/recruit/search","/api/v1/recruit/view", "/api/v1/recruit/general/jump", "/api/v1/recruit/premium/jump"
+                        ).permitAll() // 공고 전체 조회, 공고 상세 조회, 프리미엄 공고 상단 점프 목록 조회, 일반 공고 점프 목록 조회 인증 허가
                         .requestMatchers(
                                 HttpMethod.GET, "/api/v1/albareview/**", "/api/v1/albareview","/api/v1/albareview/comment"
                         ).permitAll() // 알바 후기 조회 관련 API

--- a/src/main/java/com/core/foreign/common/response/ErrorStatus.java
+++ b/src/main/java/com/core/foreign/common/response/ErrorStatus.java
@@ -61,6 +61,11 @@ public enum ErrorStatus {
     ALREADY_UPLOADED_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 업로드 했습니다."),
     FILE_NOT_PROVIDED_EXCEPTION(HttpStatus.BAD_REQUEST, "업로드할 파일이 제공되지 않았습니다."),
     ONLY_MODIFY_WRITER_USER_EXCEPTION(HttpStatus.BAD_REQUEST,"수정 권한이 없습니다."),
+    NOT_EMPLOYER_USER_EXCEPTION(HttpStatus.BAD_REQUEST,"해당 회원은 고용주가 아닙니다."),
+    NOT_PREMIUM_RECRUIT_EXCEPTION(HttpStatus.BAD_REQUEST,"해당 공고는 프리미엄 공고가 아닙니다."),
+    NOT_GENERAL_RECRUIT_EXCEPTION(HttpStatus.BAD_REQUEST,"해당 공고는 일반 공고가 아닙니다."),
+    LEAK_PREMIUM_RECRUIT_JUMP_COUNT_EXCEPTION(HttpStatus.BAD_REQUEST,"프리미엄 상단 점프 횟수가 부족합니다."),
+    LEAK_GENERAL_RECRUIT_JUMP_COUNT_EXCEPTION(HttpStatus.BAD_REQUEST,"일반 상단 점프 횟수가 부족합니다."),
 
     /**
      * 401 UNAUTHORIZED

--- a/src/main/java/com/core/foreign/common/response/SuccessStatus.java
+++ b/src/main/java/com/core/foreign/common/response/SuccessStatus.java
@@ -71,6 +71,8 @@ public enum SuccessStatus {
     PREVIEW_RECRUIT_SUCCESS(HttpStatus.OK, "공고 미리보기 조회 성공"),
     ALBA_REVIEW_COMMENT_UPDATE_SUCCESS(HttpStatus.OK,"알바 후기 댓글 수정 성공"),
     ALBA_REVIEW_COMMENT_DELETE_SUCCESS(HttpStatus.OK,"알바 후기 댓글 삭제 성공"),
+    UPDATE_TOP_JUMP_SUCCESS(HttpStatus.OK,"공고 상단 점프 성공"),
+    SEND_TOP_JUMP_COUNT_SUCCESS(HttpStatus.OK,"상단 점프 잔여 횟수 조회 성공"),
 
     /**
      * 201


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #86

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 일반, 프리미엄 상단 점프 기능을 구현하였습니다.
- 결제 처리 로직에서 상단 점프 횟수 부여 로직을 등록하였습니다.
- 기존에 등록된 프리미엄 공고 등록 횟수 로직을 toBuilder 에서 SQL로 변경하였습니다.
- 일반, 프리미엄 상단 점프 횟수 반환 기능을 구현하였습니다.
- 일반, 프리미엄 상단 점프한 공고들을 반환하는 기능을 구현하였습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 프론트에서 임시로 프리미엄 공고를 등록할수있게 점검 로직 주석 처리하였습니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
[ 일반, 프리미엄 상단 점프 ]
![image](https://github.com/user-attachments/assets/6f44b433-a0d9-4f57-85ae-8c7d74c9384a)

[ 일반, 프리미엄 상단 점프 횟수 반환 ]
![image](https://github.com/user-attachments/assets/155952c6-42a9-4517-b9d0-1b7e2f0c4f31)

[ 일반, 프리미엄 상단 점프한 공고 반환 ]
![image](https://github.com/user-attachments/assets/a2abe645-0756-4b16-8551-7bab3083fbe4)
![image](https://github.com/user-attachments/assets/325872ce-f6af-4fb9-a231-657a692099a5)
