### PR TITLE
[FIX] 공고 임시저장 데이터 처리 로직 수정

### DIFF
--- a/src/main/java/com/core/foreign/api/recruit/controller/RecruitController.java
+++ b/src/main/java/com/core/foreign/api/recruit/controller/RecruitController.java
@@ -229,8 +229,138 @@ public class RecruitController {
             @RequestPart("request") RecruitRequestDTO.GeneralRecruitRequest recruitRequest,
             @RequestPart(value = "posterImage", required = false) MultipartFile posterImage
     ) {
-        recruitService.saveGeneralRecruitDraft(securityMember.getId(), recruitRequest, posterImage);
+        recruitService.createGeneralDraft(securityMember.getId(), recruitRequest, posterImage);
         return ApiResponse.success_only(SuccessStatus.CREATE_DRAFT_RECRUIT_ARTICLE_SUCCESS);
+    }
+
+    @Operation(summary = "임시 저장된 일반 공고 수정 API",
+            description = "임시 저장된 일반 공고 데이터를 수정 합니다.<br>" +
+                    "<p>" +
+                    "title : 공고 제목 - String <br>" +
+                    "recruitStartDate : 모집 시작일 - String (ex '2025-01-01')<br>" +
+                    "recruitEndDate : 모집 종료일 - String (ex '2025-01-20') / 상시 모집일 경우 2099-12-31 로 등록<br>" +
+                    "recruitCount : 모집 인원 - int (ex 5)<br>" +
+                    "gender : 성별 - String (ex 남자 : 'male', 여자 : 'female', 무관일시 : null)<br>" +
+                    "education : 학력 조건 - String (ex '학력무관' <- 피그마, 화면정의서에 있는거랑 네이밍 같게 하면 됩니다!)<br>" +
+                    "otherConditions : 기타 조건 - String <br>" +
+                    "preferredConditions : 우대 조건  - String (ex '유사업무 경험' <- 피그마, 화면정의서에 있는거랑 네이밍 같게 하면 됩니다!)<br>" +
+                    "workDuration : 근무 기간 - String (ex '1주일이하' <- 피그마, 화면정의서에 있는거랑 네이밍 같게 하면 됩니다! 또한 기간 협의를 누를경우 '기간 협의'로 등록하면 됩니다!)<br>" +
+                    "workDurationOther : 근무 기간 기타 사항 - String (없다면 null)<br>" +
+                    "workTime : 근무 시간 - String (ex '오전~오후' <- 피그마, 화면정의서에 있는거랑 네이밍 같게 하면 됩니다! 또한 시간 협의를 누를경우 '시간 협의'로 등록하면 됩니다! / 만약 직접 선택시 '시작시간~종료시간' <- 이런 형식으로 등록하면 됩니다!<br>" +
+                    "workTimeOther : 근무 시간 기타 사항 - String (없다면 null)<br>" +
+                    "workDays : 근무 요일 - String (ex '주말 (토, 일)' <- 피그마, 화면정의서에 있는거랑 네이밍 같게 하면 됩니다! 또한 요일 협의를 누른 경우 '요일 협의'로 등록하면 됩니다! / 만약 직접 선택시 (월요일 선택할 경우) '월요일' <- 이런 형식으로 등록하면 됩니다! '<br>" +
+                    "workDaysOther : 근무 요일 기타 사항 - String (없다면 null)<br>" +
+                    "salary : 급여 정보 - String (ex 14000)<br>" +
+                    "salaryType : 급여 형태 - String (ex '월급' <- 피그마, 화면정의서에 있는거랑 네이밍 같게 하면 됩니다!)<br>" +
+                    "salaryOther : 급여 기타 사항 - String (없다면 null)<br>" +
+                    "businessFields : 업직종 리스트 - String (ex 'FOOD_BEVERAGE','STORE_SALES' <- 여러개 일경우 이렇게 하시면 됩니다!) <br>" +
+                    "applicationMethods : 지원 방법  - String (ex 'ONLINE','INQUIRY' <- 여러개 일경우 이렇게 하시면 됩니다!<br>" +
+                    "latitude : 위도 - Double (ex 36.215556)<br>" +
+                    "longitude : 경도- Double (ex 127.251855)<br>" +
+                    "zipcode : 우편 번호 - String (ex '28464')<br>" +
+                    "address1 : 주소 - String (ex '충대로1')<br>" +
+                    "address2 : 상세 주소 - String (ex '충북대학교')<br>" +
+                    "<p>" +
+                    "businessField 종류<br>" +
+                    "<p>" +
+                    "FOOD_BEVERAGE : 외식/음료,<br>" +
+                    "STORE_SALES : 매장/판매,<br>" +
+                    "PRODUCTION_CONSTRUCTION : 생산-건설,<br>" +
+                    "PRODUCTION_TECHNICAL : 생산-기술,<br>" +
+                    "OFFICE_SALES : 사무/영업,<br>" +
+                    "DRIVING_DELIVERY : 운전/배달,<br>" +
+                    "LOGISTICS_TRANSPORT : 물류/운송,<br>" +
+                    "ACCOMMODATION_CLEANING : 숙박/청소,<br>" +
+                    "CULTURE_LEISURE_LIFESTYLE : 문화/여가/생활,<br>" +
+                    "RURAL_FISHING : 농어촌/선원,<br>" +
+                    "MODEL_SHOPPING_MALL : 모델/쇼핑몰,<br>" +
+                    "EDUCATION : 교육,<br>" +
+                    "OTHER_SERVICE : 기타/서비스" +
+                    "<p>" +
+                    "applicationMethods 종류<br>" +
+                    "<p>" +
+                    "ONLINE : 온라인지원,<br>" +
+                    "INQUIRY : 문의 지원,<br>" +
+                    "VISIT : 방문 접수,<br>" +
+                    "CALL_VISIT : 전화 후 방문,<br>")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "공고 임시 저장 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+    })
+    @PutMapping(value = "/general/draft/{recruitId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<Void>> updateGeneralDraft(
+            @AuthenticationPrincipal SecurityMember securityMember,
+            @PathVariable Long recruitId,
+            @RequestPart("request") RecruitRequestDTO.GeneralRecruitRequest recruitRequest,
+            @RequestPart(value = "posterImage", required = false) MultipartFile posterImage) {
+
+        recruitService.updateGeneralDraft(securityMember.getId(), recruitId, recruitRequest, posterImage);
+        return ApiResponse.success_only(SuccessStatus.CREATE_DRAFT_RECRUIT_ARTICLE_SUCCESS);
+    }
+
+        @Operation(summary = "일반 공고 퍼블리싱 API",
+            description = "임시 저장한 일반 공고를 최종 퍼블리싱 합니다.<br>" +
+                    "<p>" +
+                    "title : 공고 제목 - String <br>" +
+                    "recruitStartDate : 모집 시작일 - String (ex '2025-01-01')<br>" +
+                    "recruitEndDate : 모집 종료일 - String (ex '2025-01-20') / 상시 모집일 경우 2099-12-31 로 등록<br>" +
+                    "recruitCount : 모집 인원 - int (ex 5)<br>" +
+                    "gender : 성별 - String (ex 남자 : 'male', 여자 : 'female', 무관일시 : null)<br>" +
+                    "education : 학력 조건 - String (ex '학력무관' <- 피그마, 화면정의서에 있는거랑 네이밍 같게 하면 됩니다!)<br>" +
+                    "otherConditions : 기타 조건 - String <br>" +
+                    "preferredConditions : 우대 조건  - String (ex '유사업무 경험' <- 피그마, 화면정의서에 있는거랑 네이밍 같게 하면 됩니다!)<br>" +
+                    "workDuration : 근무 기간 - String (ex '1주일이하' <- 피그마, 화면정의서에 있는거랑 네이밍 같게 하면 됩니다! 또한 기간 협의를 누를경우 '기간 협의'로 등록하면 됩니다!)<br>" +
+                    "workDurationOther : 근무 기간 기타 사항 - String (없다면 null)<br>" +
+                    "workTime : 근무 시간 - String (ex '오전~오후' <- 피그마, 화면정의서에 있는거랑 네이밍 같게 하면 됩니다! 또한 시간 협의를 누를경우 '시간 협의'로 등록하면 됩니다! / 만약 직접 선택시 '시작시간~종료시간' <- 이런 형식으로 등록하면 됩니다!<br>" +
+                    "workTimeOther : 근무 시간 기타 사항 - String (없다면 null)<br>" +
+                    "workDays : 근무 요일 - String (ex '주말 (토, 일)' <- 피그마, 화면정의서에 있는거랑 네이밍 같게 하면 됩니다! 또한 요일 협의를 누른 경우 '요일 협의'로 등록하면 됩니다! / 만약 직접 선택시 (월요일 선택할 경우) '월요일' <- 이런 형식으로 등록하면 됩니다! '<br>" +
+                    "workDaysOther : 근무 요일 기타 사항 - String (없다면 null)<br>" +
+                    "salary : 급여 정보 - String (ex 14000)<br>" +
+                    "salaryType : 급여 형태 - String (ex '월급' <- 피그마, 화면정의서에 있는거랑 네이밍 같게 하면 됩니다!)<br>" +
+                    "salaryOther : 급여 기타 사항 - String (없다면 null)<br>" +
+                    "businessFields : 업직종 리스트 - String (ex 'FOOD_BEVERAGE','STORE_SALES' <- 여러개 일경우 이렇게 하시면 됩니다!) <br>" +
+                    "applicationMethods : 지원 방법  - String (ex 'ONLINE','INQUIRY' <- 여러개 일경우 이렇게 하시면 됩니다!<br>" +
+                    "latitude : 위도 - Double (ex 36.215556)<br>" +
+                    "longitude : 경도- Double (ex 127.251855)<br>" +
+                    "zipcode : 우편 번호 - String (ex '28464')<br>" +
+                    "address1 : 주소 - String (ex '충대로1')<br>" +
+                    "address2 : 상세 주소 - String (ex '충북대학교')<br>" +
+                    "<p>" +
+                    "businessField 종류<br>" +
+                    "<p>" +
+                    "FOOD_BEVERAGE : 외식/음료,<br>" +
+                    "STORE_SALES : 매장/판매,<br>" +
+                    "PRODUCTION_CONSTRUCTION : 생산-건설,<br>" +
+                    "PRODUCTION_TECHNICAL : 생산-기술,<br>" +
+                    "OFFICE_SALES : 사무/영업,<br>" +
+                    "DRIVING_DELIVERY : 운전/배달,<br>" +
+                    "LOGISTICS_TRANSPORT : 물류/운송,<br>" +
+                    "ACCOMMODATION_CLEANING : 숙박/청소,<br>" +
+                    "CULTURE_LEISURE_LIFESTYLE : 문화/여가/생활,<br>" +
+                    "RURAL_FISHING : 농어촌/선원,<br>" +
+                    "MODEL_SHOPPING_MALL : 모델/쇼핑몰,<br>" +
+                    "EDUCATION : 교육,<br>" +
+                    "OTHER_SERVICE : 기타/서비스" +
+                    "<p>" +
+                    "applicationMethods 종류<br>" +
+                    "<p>" +
+                    "ONLINE : 온라인지원,<br>" +
+                    "INQUIRY : 문의 지원,<br>" +
+                    "VISIT : 방문 접수,<br>" +
+                    "CALL_VISIT : 전화 후 방문,<br>")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "공고 등록 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+    })
+    @PutMapping(value = "/general/draft/{recruitId}/publish", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<Void>> publishGeneralDraft(
+            @AuthenticationPrincipal SecurityMember securityMember,
+            @PathVariable Long recruitId,
+            @RequestPart("request") RecruitRequestDTO.GeneralRecruitRequest recruitRequest,
+            @RequestPart(value = "posterImage", required = false) MultipartFile posterImage) {
+
+        recruitService.publishGeneralDraft(securityMember.getId(), recruitId, recruitRequest, posterImage);
+        return ApiResponse.success_only(SuccessStatus.CREATE_RECRUIT_ARTICLE_SUCCESS);
     }
 
     @Operation(summary = "프리미엄 공고 임시저장 API",
@@ -304,8 +434,8 @@ public class RecruitController {
         return ApiResponse.success_only(SuccessStatus.CREATE_DRAFT_RECRUIT_ARTICLE_SUCCESS);
     }
 
-    @Operation(summary = "일반 공고 퍼블리싱 API",
-            description = "임시 저장한 일반 공고를 최종 퍼블리싱 합니다.<br>" +
+    @Operation(summary = "임시 저장된 프리미엄 공고 수정 API",
+            description = "임시 저장된 프리미엄 공고 데이터를 수정 합니다.<br>" +
                     "<p>" +
                     "title : 공고 제목 - String <br>" +
                     "recruitStartDate : 모집 시작일 - String (ex '2025-01-01')<br>" +
@@ -353,22 +483,30 @@ public class RecruitController {
                     "ONLINE : 온라인지원,<br>" +
                     "INQUIRY : 문의 지원,<br>" +
                     "VISIT : 방문 접수,<br>" +
-                    "CALL_VISIT : 전화 후 방문,<br>")
+                    "CALL_VISIT : 전화 후 방문,<br>" +
+                    "<p>" +
+                    "Portfolios<br>" +
+                    "title : 질문 제목 - String<br>" +
+                    "type : 질문 유형 - String (LONG_TEXT : 장문형 / SHORT_TEXT : 단답형 / FILE_UPLOAD : 파일 업로드)<br>" +
+                    "required : 필수 질문 - String<br>" +
+                    "maxFileCount : 최대 업로드 가능 갯수 - Int (FILE_UPLOAD 일때만, 다른 유형일 경우 null)<br>" +
+                    "maxFileSize : 최대 업로드 가능 파일 사이즈 - Long (FILE_UPLOAD 일때만, 다른 유형일 경우 null)<br>")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "공고 등록 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
     })
-    @PutMapping(value = "/general/{recruitId}/publish", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ApiResponse<Void>> publishGeneralRecruit(
+    @PutMapping(value = "/premium/draft/{recruitId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<Void>> updatePremiumDraft(
+            @AuthenticationPrincipal SecurityMember securityMember,
             @PathVariable Long recruitId,
-            @RequestPart("request") RecruitRequestDTO.GeneralRecruitRequest recruitRequest,
-            @RequestPart(value = "posterImage", required = false) MultipartFile posterImage
-    ) {
-        recruitService.publishGeneralRecruit(recruitId, recruitRequest, posterImage);
-        return ApiResponse.success_only(SuccessStatus.CREATE_RECRUIT_ARTICLE_SUCCESS);
+            @RequestPart("request") RecruitRequestDTO.PremiumRecruitRequest recruitRequest,
+            @RequestPart(value = "posterImage", required = false) MultipartFile posterImage) {
+
+        recruitService.updatePremiumDraft(securityMember.getId(), recruitId, recruitRequest, posterImage);
+        return ApiResponse.success_only(SuccessStatus.CREATE_DRAFT_RECRUIT_ARTICLE_SUCCESS);
     }
 
-    @Operation(summary = "프리미엄 공고 퍼블리싱 API",
+        @Operation(summary = "프리미엄 공고 퍼블리싱 API",
             description = "임시 저장한 프리미엄 공고를 최종 퍼블리싱 합니다.<br>" +
                     "<p>" +
                     "title : 공고 제목 - String <br>" +
@@ -429,13 +567,14 @@ public class RecruitController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "공고 등록 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
     })
-    @PutMapping(value = "/premium/{recruitId}/publish", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ApiResponse<Void>> publishPremiumRecruit(
+    @PutMapping(value = "/premium/draft/{recruitId}/publish", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<Void>> publishPremiumDraft(
+            @AuthenticationPrincipal SecurityMember securityMember,
             @PathVariable Long recruitId,
             @RequestPart("request") RecruitRequestDTO.PremiumRecruitRequest recruitRequest,
-            @RequestPart(value = "posterImage", required = false) MultipartFile posterImage
-    ) {
-        recruitService.publishPremiumRecruit(recruitId, recruitRequest, posterImage);
+            @RequestPart(value = "posterImage", required = false) MultipartFile posterImage) {
+
+        recruitService.publishPremiumDraft(securityMember.getId(), recruitId, recruitRequest, posterImage);
         return ApiResponse.success_only(SuccessStatus.CREATE_RECRUIT_ARTICLE_SUCCESS);
     }
 

--- a/src/main/java/com/core/foreign/api/recruit/dto/MyDraftRecruitResponseDTO.java
+++ b/src/main/java/com/core/foreign/api/recruit/dto/MyDraftRecruitResponseDTO.java
@@ -1,6 +1,7 @@
 package com.core.foreign.api.recruit.dto;
 
 import com.core.foreign.api.recruit.entity.Recruit;
+import com.core.foreign.api.recruit.entity.RecruitType;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -11,8 +12,7 @@ public class MyDraftRecruitResponseDTO {
     private String title; // 공고 제목
     private LocalDateTime createdAt;  // 생성 날짜
     private LocalDateTime updatedAt;  // 수정 날짜
-
-
+    private RecruitType recruitType;
 
     public static MyDraftRecruitResponseDTO from(Recruit recruit){
         MyDraftRecruitResponseDTO dto = new MyDraftRecruitResponseDTO();
@@ -21,6 +21,7 @@ public class MyDraftRecruitResponseDTO {
         dto.title=recruit.getTitle();
         dto.createdAt=recruit.getCreatedAt();
         dto.updatedAt=recruit.getUpdatedAt();
+        dto.recruitType=recruit.getRecruitType();
         return dto;
     }
 }

--- a/src/main/java/com/core/foreign/api/recruit/entity/GeneralRecruit.java
+++ b/src/main/java/com/core/foreign/api/recruit/entity/GeneralRecruit.java
@@ -3,6 +3,7 @@ package com.core.foreign.api.recruit.entity;
 import com.core.foreign.api.business_field.BusinessField;
 import com.core.foreign.api.member.entity.Address;
 import com.core.foreign.api.member.entity.Member;
+import com.core.foreign.api.recruit.dto.RecruitRequestDTO;
 import jakarta.persistence.Entity;
 import jakarta.persistence.PrimaryKeyJoinColumn;
 import jakarta.persistence.Table;
@@ -75,6 +76,37 @@ public class GeneralRecruit extends Recruit {
                 jumpDate,
                 recruitPublishStatus
         );
+    }
+
+    public void updateFrom(RecruitRequestDTO.GeneralRecruitRequest request, String posterImageUrl) {
+        this.title = request.getTitle();
+        this.address = request.getAddress();
+        if (request.getBusinessFields() != null) {
+            this.businessFields = new java.util.HashSet<>(request.getBusinessFields());
+        }
+        this.latitude = request.getLatitude();
+        this.longitude = request.getLongitude();
+        this.recruitStartDate = request.getRecruitStartDate();
+        this.recruitEndDate = request.getRecruitEndDate();
+        this.gender = request.getGender();
+        this.education = request.getEducation();
+        this.otherConditions = request.getOtherConditions();
+        this.preferredConditions = request.getPreferredConditions();
+        this.workDuration = request.getWorkDuration();
+        this.workDurationOther = request.getWorkDurationOther();
+        this.workTime = request.getWorkTime();
+        this.workTimeOther = request.getWorkTimeOther();
+        this.workDays = request.getWorkDays();
+        this.workDaysOther = request.getWorkDaysOther();
+        this.salary = request.getSalary();
+        this.salaryType = request.getSalaryType();
+        this.salaryOther = request.getSalaryOther();
+        if (request.getApplicationMethods() != null) {
+            this.applicationMethods = new java.util.HashSet<>(request.getApplicationMethods());
+        }
+        if (posterImageUrl != null) {
+            this.posterImageUrl = posterImageUrl;
+        }
     }
 
 }

--- a/src/main/java/com/core/foreign/api/recruit/entity/PremiumRecruit.java
+++ b/src/main/java/com/core/foreign/api/recruit/entity/PremiumRecruit.java
@@ -3,6 +3,7 @@ package com.core.foreign.api.recruit.entity;
 import com.core.foreign.api.business_field.BusinessField;
 import com.core.foreign.api.member.entity.Address;
 import com.core.foreign.api.member.entity.Member;
+import com.core.foreign.api.recruit.dto.RecruitRequestDTO;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -90,6 +91,52 @@ public class PremiumRecruit extends Recruit {
     public void addPortfolios(List<Portfolio> portfolioList) {
         for (Portfolio portfolio : portfolioList) {
             this.addPortfolio(portfolio);
+        }
+    }
+
+    public void updateFrom(RecruitRequestDTO.PremiumRecruitRequest request, String posterImageUrl) {
+        this.title = request.getTitle();
+        this.address = request.getAddress();
+        if (request.getBusinessFields() != null) {
+            this.businessFields = new java.util.HashSet<>(request.getBusinessFields());
+        }
+        this.latitude = request.getLatitude();
+        this.longitude = request.getLongitude();
+        this.recruitStartDate = request.getRecruitStartDate();
+        this.recruitEndDate = request.getRecruitEndDate();
+        this.gender = request.getGender();
+        this.education = request.getEducation();
+        this.otherConditions = request.getOtherConditions();
+        this.preferredConditions = request.getPreferredConditions();
+        this.workDuration = request.getWorkDuration();
+        this.workDurationOther = request.getWorkDurationOther();
+        this.workTime = request.getWorkTime();
+        this.workTimeOther = request.getWorkTimeOther();
+        this.workDays = request.getWorkDays();
+        this.workDaysOther = request.getWorkDaysOther();
+        this.salary = request.getSalary();
+        this.salaryType = request.getSalaryType();
+        this.salaryOther = request.getSalaryOther();
+        if (request.getApplicationMethods() != null) {
+            this.applicationMethods = new java.util.HashSet<>(request.getApplicationMethods());
+        }
+        if (posterImageUrl != null) {
+            this.posterImageUrl = posterImageUrl;
+        }
+    }
+
+    public void updatePortfolios(java.util.List<RecruitRequestDTO.PremiumRecruitRequest.PortfolioRequest> portfolioDTOs) {
+        this.portfolios.clear();
+        if (portfolioDTOs != null) {
+            for (RecruitRequestDTO.PremiumRecruitRequest.PortfolioRequest dto : portfolioDTOs) {
+                Portfolio portfolio = Portfolio.builder()
+                        .title(dto.getTitle())
+                        .type(dto.getType())
+                        .isRequired(dto.isRequired())
+                        .maxFileCount(dto.getMaxFileCount())
+                        .build();
+                this.addPortfolio(portfolio);
+            }
         }
     }
 }

--- a/src/main/java/com/core/foreign/api/recruit/entity/Recruit.java
+++ b/src/main/java/com/core/foreign/api/recruit/entity/Recruit.java
@@ -100,6 +100,10 @@ public abstract class Recruit extends BaseTimeEntity {
         this.jumpDate = LocalDateTime.now();
     }
 
+    public void updatePublishStatus(RecruitPublishStatus status) {
+        this.recruitPublishStatus = status;
+    }
+
     protected Recruit(String title,
                       Member employer,
                       Address address,

--- a/src/main/java/com/core/foreign/api/recruit/repository/RecruitRepository.java
+++ b/src/main/java/com/core/foreign/api/recruit/repository/RecruitRepository.java
@@ -1,9 +1,7 @@
 package com.core.foreign.api.recruit.repository;
 
 import com.core.foreign.api.member.entity.Member;
-import com.core.foreign.api.recruit.entity.Recruit;
-import com.core.foreign.api.recruit.entity.RecruitPublishStatus;
-import com.core.foreign.api.recruit.entity.RecruitType;
+import com.core.foreign.api.recruit.entity.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
@@ -43,15 +41,27 @@ public interface RecruitRepository
     Optional<Recruit> findByIdFetchJoin(@Param("recruitId") Long recruitId);
 
     @Query("select r from Recruit r" +
-            " where r.employer.id=:employerId and r.recruitType=:recruitType and r.recruitPublishStatus='PUBLISHED'")
-    Page<Recruit> findByEmployerIdAndRecruitType(@Param("employerId")Long employerId, @Param("recruitType")RecruitType recruitType, Pageable pageable);
-
-    @Query("select r from Recruit r" +
             " where r.employer.id=:employerId and r.recruitPublishStatus='PUBLISHED'")
     Page<Recruit> findPublishedRecruitsByEmployerId(Long employerId, Pageable pageable);
 
     // 해당 공고 유형(recruitType)이고 jumpDate가 설정된 공고를 jumpDate 내림차순으로 조회
     @Query("SELECT r FROM Recruit r WHERE r.recruitType = :recruitType AND r.jumpDate IS NOT NULL ORDER BY r.jumpDate DESC")
     Page<Recruit> findByRecruitTypeAndJumpDateIsNotNullOrderByJumpDateDesc(@Param("recruitType") RecruitType recruitType, Pageable pageable);
+
+    @Query("select gr from GeneralRecruit gr where gr.id = :id and gr.recruitPublishStatus = :status")
+    Optional<GeneralRecruit> findGeneralDraftById(Long id, RecruitPublishStatus status);
+
+    default Optional<GeneralRecruit> findGeneralDraftById(Long id) {
+        return findGeneralDraftById(id, RecruitPublishStatus.DRAFT);
+    }
+
+    @Query("select pr from PremiumRecruit pr where pr.id = :id and pr.recruitPublishStatus = :status")
+    Optional<PremiumRecruit> findPremiumDraftById(Long id, RecruitPublishStatus status);
+
+    default Optional<PremiumRecruit> findPremiumDraftById(Long id) {
+        return findPremiumDraftById(id, RecruitPublishStatus.DRAFT);
+    }
+
+    boolean existsByEmployerAndRecruitPublishStatus(Member employer, RecruitPublishStatus status);
 
 }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #110

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 기존 공고 임시저장 데이터 처리 로직을 수정하였습니다.
- 1. 임시저장 등록 API
- 2. 임시 저장된 데이터 추가로 저장하는 API
- 3. 임시저장 퍼블리싱 API

- 임시 저장된 공고 존재 여부 체크 API 로직 수정하였습니다.
- 고용인 내 임시 공고 조회 API 공고타입 반환 로직 추가하였습니다.
## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
![image](https://github.com/user-attachments/assets/d30d5fe4-856e-4a6f-9936-651b8966db64)
