### PR TITLE
[FEAT] 메인 검색 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-//	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+//	developmentOnly '.org.springframework.boot:spring-boot-devtools'
 
 	//coolSMS
 	implementation 'net.nurigo:sdk:4.3.2'
@@ -50,7 +50,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
 	// H2
-//	runtimeOnly 'com.h2database:h2'
+	//runtimeOnly 'com.h2database:h2'
 
 	// MYSQL
 	implementation 'com.mysql:mysql-connector-j:9.1.0'
@@ -66,7 +66,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	//Querydsl 추가
-	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
 	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"

--- a/src/main/java/com/core/foreign/api/recruit/controller/RecruitController.java
+++ b/src/main/java/com/core/foreign/api/recruit/controller/RecruitController.java
@@ -1001,4 +1001,21 @@ public class RecruitController {
         return ApiResponse.success(SuccessStatus.SEND_RECRUIT_ALL_LIST_SUCCESS, response);
     }
 
+    @Operation(summary = "메인 공고 조회 API",
+            description = "공고 명, 회사점표명을 입력받아 관련된 공고를 연관도 높은순으로 반환합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "공고 검색 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다.")
+    })
+    @GetMapping("/keyword/search")
+    public ResponseEntity<ApiResponse<PageResponseDTO<RecruitListResponseDTO>>> searchRecruit(
+            @RequestParam("query") String query,
+            @RequestParam(value = "page", defaultValue = "0") Integer page,
+            @RequestParam(value = "size", defaultValue = "10") Integer size) {
+
+        PageResponseDTO<RecruitListResponseDTO> response = recruitService.searchRecruits(query, page, size);
+        return ApiResponse.success(SuccessStatus.SEARCH_RECRUIT_SUCESS, response);
+    }
+
+
 }

--- a/src/main/java/com/core/foreign/api/recruit/repository/RecruitRepositoryImpl.java
+++ b/src/main/java/com/core/foreign/api/recruit/repository/RecruitRepositoryImpl.java
@@ -1,10 +1,15 @@
 package com.core.foreign.api.recruit.repository;
 
+import com.core.foreign.api.member.entity.QEmployer;
 import com.core.foreign.api.recruit.entity.QRecruit;
 import com.core.foreign.api.recruit.entity.Recruit;
 import com.core.foreign.api.recruit.entity.RecruitPublishStatus;
 import com.core.foreign.api.recruit.entity.RecruitType;
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
@@ -61,6 +66,49 @@ public class RecruitRepositoryImpl implements RecruitRepositoryQueryDSL{
         return recruitType==null?null:recruit.recruitType.eq(recruitType);
     }
 
+    @Override
+    public Page<Recruit> searchRecruit(String searchQuery, Pageable pageable) {
 
+        QRecruit qRecruit = QRecruit.recruit;
+        QEmployer qEmployer = QEmployer.employer;
+
+        // 검색어 전처리: 좌우 공백 제거 후 소문자로 변환
+        String lowerQuery = searchQuery.trim().toLowerCase();
+
+        // 검색 조건:
+        // 1. 공고 제목이 검색어를 포함하거나
+        // 2. treat()를 사용하여 employer를 QEmployer로 변환한 후 회사점포명(companyName)이 검색어를 포함하는 경우
+        BooleanBuilder predicate = new BooleanBuilder();
+        predicate.and(
+                qRecruit.title.toLowerCase().contains(lowerQuery)
+                        .or(
+                                JPAExpressions.treat(qRecruit.employer, QEmployer.class)
+                                        .companyName.toLowerCase().contains(lowerQuery)
+                        )
+        );
+
+        // 연관도 점수: 제목이 완전 일치하면 1, 제목이 검색어로 시작하면 2, 제목에 포함되면 3, 그 외에는 4
+        NumberExpression<Integer> relevance = new CaseBuilder()
+                .when(qRecruit.title.equalsIgnoreCase(searchQuery)).then(1)
+                .when(qRecruit.title.startsWithIgnoreCase(searchQuery)).then(2)
+                .when(qRecruit.title.containsIgnoreCase(searchQuery)).then(3)
+                .otherwise(4);
+
+        // 정렬: 연관도 오름차순 정렬, 동일하면 createdAt 내림차순(최신순) 정렬
+        List<Recruit> content = queryFactory
+                .selectFrom(qRecruit)
+                .where(predicate)
+                .orderBy(relevance.asc(), qRecruit.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(qRecruit.count())
+                .from(qRecruit)
+                .where(predicate);
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
 
 }

--- a/src/main/java/com/core/foreign/api/recruit/repository/RecruitRepositoryQueryDSL.java
+++ b/src/main/java/com/core/foreign/api/recruit/repository/RecruitRepositoryQueryDSL.java
@@ -9,4 +9,6 @@ import org.springframework.data.domain.Pageable;
 public interface RecruitRepositoryQueryDSL {
     Page<Recruit> getMyRecruits(Long employerId, RecruitType recruitType, RecruitPublishStatus recruitPublishStatus,
                                 boolean excludeExpired , Pageable pageable);
+
+    Page<Recruit> searchRecruit(String searchQuery, Pageable pageable);
 }

--- a/src/main/java/com/core/foreign/api/recruit/service/RecruitService.java
+++ b/src/main/java/com/core/foreign/api/recruit/service/RecruitService.java
@@ -790,4 +790,16 @@ public class RecruitService {
         Page<Recruit> recruitPage = recruitRepository.findByRecruitTypeAndJumpDateIsNotNullOrderByJumpDateDesc(recruitType, pageable);
         return recruitPage.map(this::convertToRecruitListResponseDTO);
     }
+
+    // 공고 검색
+    @Transactional(readOnly = true)
+    public PageResponseDTO<RecruitListResponseDTO> searchRecruits(String query, int page, int size) {
+
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Recruit> recruitPage = recruitRepository.searchRecruit(query, pageable);
+        Page<RecruitListResponseDTO> dtoPage = recruitPage.map(this::convertToRecruitListResponseDTO);
+
+        return PageResponseDTO.of(dtoPage);
+    }
+
 }

--- a/src/main/java/com/core/foreign/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/core/foreign/common/config/security/SecurityConfig.java
@@ -71,8 +71,8 @@ public class SecurityConfig {
                                 "/api/v1/member/verification-phone-code", "/api/v1/member/find-user-id", "/api/v1/member/employer/company-validate"
                         ).permitAll() // 회원가입, 로그인, 토큰 재발급, 이메일 인증, 사업자등록 번호 인증 허가
                         .requestMatchers(
-                                "/api/v1/recruit/search","/api/v1/recruit/view", "/api/v1/recruit/general/jump", "/api/v1/recruit/premium/jump"
-                        ).permitAll() // 공고 전체 조회, 공고 상세 조회, 프리미엄 공고 상단 점프 목록 조회, 일반 공고 점프 목록 조회 인증 허가
+                                "/api/v1/recruit/search","/api/v1/recruit/view", "/api/v1/recruit/general/jump", "/api/v1/recruit/premium/jump", "/api/v1/recruit/keyword/search"
+                        ).permitAll() // 공고 전체 조회, 공고 검색, 공고 상세 조회, 프리미엄 공고 상단 점프 목록 조회, 일반 공고 점프 목록 조회 인증 허가
                         .requestMatchers(
                                 HttpMethod.GET, "/api/v1/albareview/**", "/api/v1/albareview","/api/v1/albareview/comment","/api/v1/albareview/search"
                         ).permitAll() // 알바 후기 조회, 검색 관련 API

--- a/src/main/java/com/core/foreign/common/response/SuccessStatus.java
+++ b/src/main/java/com/core/foreign/common/response/SuccessStatus.java
@@ -74,6 +74,7 @@ public enum SuccessStatus {
     UPDATE_TOP_JUMP_SUCCESS(HttpStatus.OK,"공고 상단 점프 성공"),
     SEND_TOP_JUMP_COUNT_SUCCESS(HttpStatus.OK,"상단 점프 잔여 횟수 조회 성공"),
     ALBA_REVIEW_SEARCH_SUCCESS(HttpStatus.OK, "알바 후기 검색 성공"),
+    SEARCH_RECRUIT_SUCESS(HttpStatus.OK,"공고 검색 성공"),
 
     /**
      * 201


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #97

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- QueryDSL을 활용하여 메인 검색 기능을 구현하였습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 검색 조건
- 1. 공고 제목이 검색어를 포함하거나
- 2. 회사점포명(companyName)이 검색어를 포함하는 경우

- 연관도 점수에 따라서 정렬하도록 구현하였습니다.
- 연관도 점수: 제목이 완전 일치하면 1, 제목이 검색어로 시작하면 2, 제목에 포함되면 3, 그 외에는 4

- 정렬: 연관도 오름차순 정렬, 동일하면 createdAt 내림차순(최신순) 정렬

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
![image](https://github.com/user-attachments/assets/d678c413-b50b-4179-b157-069b07fa77d7)
