### PR TITLE
[FEAT] 프리미엄 공고 목록 조회 구현

### DIFF
--- a/src/main/java/com/core/foreign/api/recruit/controller/RecruitController.java
+++ b/src/main/java/com/core/foreign/api/recruit/controller/RecruitController.java
@@ -654,7 +654,8 @@ public class RecruitController {
     }
 
     @Operation(summary = "공고 전체 조회 API",
-            description = "등록되어있는 공고들을 전체 조회 합니다.")
+            description = "등록되어있는 공고들을 전체 조회 합니다. <br>"+
+                    "상단 점프한 공고는 jump = true로 표시됩니다.")
     @GetMapping("/search")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "공고 전체 조회 성공"),
@@ -683,6 +684,43 @@ public class RecruitController {
                 .build();
 
         Page<RecruitListResponseDTO> recruitPage = recruitService.getRecruitsWithFilters(condition);
+        PageResponseDTO<RecruitListResponseDTO> pageResponse = PageResponseDTO.of(recruitPage);
+        return ApiResponse.success(SuccessStatus.SEND_RECRUIT_ALL_LIST_SUCCESS, pageResponse);
+    }
+
+    @Operation(
+            summary = "프리미엄 공고 전체 조회 API",
+            description = "프리미엄 공고 만 조회합니다. " +
+                    "상단 점프한 공고는 jump = true로 표시됩니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "공고 전체 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다.")
+    })
+    @GetMapping("/premium/search")
+    public ResponseEntity<ApiResponse<PageResponseDTO<RecruitListResponseDTO>>> getPremiumRecruits(
+            @RequestParam(required = false, defaultValue = "0") Integer page,
+            @RequestParam(required = false, defaultValue = "10") Integer size,
+            @RequestParam(required = false) List<BusinessField> businessFields,
+            @RequestParam(required = false) List<String> workDurations,
+            @RequestParam(required = false) List<String> workDays,
+            @RequestParam(required = false) List<String> workTimes,
+            @RequestParam(required = false) String gender,
+            @RequestParam(required = false) String salaryType
+    ) {
+        // 검색조건 생성
+        RecruitSearchConditionDTO condition = RecruitSearchConditionDTO.builder()
+                .page(page)
+                .size(size)
+                .businessFields(businessFields)
+                .workDurations(workDurations)
+                .workDays(workDays)
+                .workTimes(workTimes)
+                .gender(gender)
+                .salaryType(salaryType)
+                .build();
+
+        Page<RecruitListResponseDTO> recruitPage = recruitService.getPremiumRecruitsWithFilters(condition);
         PageResponseDTO<RecruitListResponseDTO> pageResponse = PageResponseDTO.of(recruitPage);
         return ApiResponse.success(SuccessStatus.SEND_RECRUIT_ALL_LIST_SUCCESS, pageResponse);
     }

--- a/src/main/java/com/core/foreign/api/recruit/dto/RecruitListResponseDTO.java
+++ b/src/main/java/com/core/foreign/api/recruit/dto/RecruitListResponseDTO.java
@@ -31,4 +31,5 @@ public class RecruitListResponseDTO {
     private String recruitPeriod;              // 모집기간
     private Set<ApplyMethod> applicationMethods;    // 접수방법
     private RecruitType recruitType;           // GENERAL or PREMIUM
+    private boolean isJump;                     // 상단 점프 여부
 }

--- a/src/main/java/com/core/foreign/api/recruit/entity/PremiumManage.java
+++ b/src/main/java/com/core/foreign/api/recruit/entity/PremiumManage.java
@@ -29,7 +29,7 @@ public class PremiumManage {
     public PremiumManage(Employer employer) {
         this.employer = employer;
         this.premiumCount = 0;
-        this.premiumJumpCount = 5;
-        this.normalJumpCount = 5;
+        this.premiumJumpCount = 0;
+        this.normalJumpCount = 0;
     }
 }

--- a/src/main/java/com/core/foreign/api/recruit/service/RecruitSpecifications.java
+++ b/src/main/java/com/core/foreign/api/recruit/service/RecruitSpecifications.java
@@ -2,6 +2,7 @@ package com.core.foreign.api.recruit.service;
 
 import com.core.foreign.api.business_field.BusinessField;
 import com.core.foreign.api.recruit.entity.Recruit;
+import com.core.foreign.api.recruit.entity.RecruitType;
 import com.core.foreign.api.recruit.entity.RecruitPublishStatus;
 import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.JoinType;
@@ -103,4 +104,15 @@ public class RecruitSpecifications {
             return cb.equal(root.get("salaryType"), salaryType);
         };
     }
+
+    // 프리미엄 필터
+    public static Specification<Recruit> isPremium() {
+        return (root, query, cb) -> {
+            if (query != null) {
+                query.distinct(true);
+            }
+            return cb.equal(root.get("recruitType"), RecruitType.PREMIUM);
+        };
+    }
+
 }

--- a/src/main/java/com/core/foreign/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/core/foreign/common/config/security/SecurityConfig.java
@@ -71,8 +71,8 @@ public class SecurityConfig {
                                 "/api/v1/member/verification-phone-code", "/api/v1/member/find-user-id", "/api/v1/member/employer/company-validate"
                         ).permitAll() // 회원가입, 로그인, 토큰 재발급, 이메일 인증, 사업자등록 번호 인증 허가
                         .requestMatchers(
-                                "/api/v1/recruit/search","/api/v1/recruit/view", "/api/v1/recruit/general/jump", "/api/v1/recruit/premium/jump", "/api/v1/recruit/keyword/search"
-                        ).permitAll() // 공고 전체 조회, 공고 검색, 공고 상세 조회, 프리미엄 공고 상단 점프 목록 조회, 일반 공고 점프 목록 조회 인증 허가
+                                "/api/v1/recruit/search","/api/v1/recruit/premium/search","/api/v1/recruit/view", "/api/v1/recruit/general/jump", "/api/v1/recruit/premium/jump", "/api/v1/recruit/keyword/search"
+                        ).permitAll() // 공고(프리미엄,일반/ 프리미엄) 전체 조회, 공고 검색, 공고 상세 조회, 프리미엄 공고 상단 점프 목록 조회, 일반 공고 점프 목록 조회 인증 허가
                         .requestMatchers(
                                 HttpMethod.GET, "/api/v1/albareview/**", "/api/v1/albareview","/api/v1/albareview/comment","/api/v1/albareview/search"
                         ).permitAll() // 알바 후기 조회, 검색 관련 API


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #142

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 프리미엄 공고 목록 조회하는 기능을 구현하였습니다.
- 기존 공고 전체 조회 API 로직을 조회할때 필터가 없다면 상단 광고를 한 공고를 우선적으로 반환하도록 수정하였습니다.
- 프리미엄 공고 목록 조회 API 스프링 시큐리티 인증 해제하였습니다.
## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
[ 프리미엄 공고 조회 ] 
![image](https://github.com/user-attachments/assets/b6c15ee7-2cd3-40e8-9313-2cd49870783e)
 