### PR TITLE
[FEAT] 고용인신뢰도 계산 및 지연 현황 일부 기능 개발

### DIFF
--- a/src/main/java/com/core/foreign/api/member/dto/EmployerReliabilityDTO.java
+++ b/src/main/java/com/core/foreign/api/member/dto/EmployerReliabilityDTO.java
@@ -1,0 +1,38 @@
+package com.core.foreign.api.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class EmployerReliabilityDTO {
+    private Long approveCnt; // 모집 승인 개수
+    private Long contractCompletedCnt; // 계약 완료 개수
+
+    public Integer getReliability() {
+        approveCnt = approveCnt == null ? 0 : approveCnt;
+        contractCompletedCnt = contractCompletedCnt == null ? 0 : contractCompletedCnt;
+
+        if (approveCnt == 0) {
+            return 0;
+        }
+
+        if (contractCompletedCnt == 0) {
+            return 0;
+        }
+
+        double reliability = ((double) contractCompletedCnt / approveCnt) * 100;
+
+        if (reliability >= 100) {
+            return 100;
+        } else if (reliability >= 90) {
+            return 90;
+        } else if (reliability >= 70) {
+            return 70;
+        } else if (reliability >= 50) {
+            return 50;
+        } else {
+            return 0;
+        }
+    }
+}

--- a/src/main/java/com/core/foreign/api/member/repository/EmployerRepository.java
+++ b/src/main/java/com/core/foreign/api/member/repository/EmployerRepository.java
@@ -1,0 +1,19 @@
+package com.core.foreign.api.member.repository;
+
+import com.core.foreign.api.member.dto.EmployerReliabilityDTO;
+import com.core.foreign.api.member.entity.Employer;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface EmployerRepository extends JpaRepository<Employer, Long> {
+    @Query(value = "SELECT " +
+            "sum(CASE WHEN r2.RECRUITMENT_STATUS = 'approved' THEN 1 ELSE 0 END), " +
+            "sum(CASE WHEN r2.CONTRACT_STATUS = 'COMPLETED' THEN 1 ELSE 0 END) " +
+            "FROM employer e " +
+            "JOIN recruit r1 ON r1.employer_id = e.id " +
+            "JOIN resume r2 ON r2.recruit_id = r1.id " +
+            "WHERE e.id = :employerId "
+            , nativeQuery = true)
+    EmployerReliabilityDTO getEmployerReliability(@Param("employerId") Long employerId);
+}

--- a/src/main/java/com/core/foreign/api/recruit/dto/RecruitmentApplyStatusDTO.java
+++ b/src/main/java/com/core/foreign/api/recruit/dto/RecruitmentApplyStatusDTO.java
@@ -25,13 +25,9 @@ public class RecruitmentApplyStatusDTO {
         dto.title = recruit.getTitle();
         dto.recruitStartDate=recruit.getRecruitStartDate();
         dto.recruitEndDate=recruit.getRecruitEndDate();
-       /* dto.workDuration = recruit.getWorkDuration();
+        dto.workDuration = recruit.getWorkDuration();
         dto.workDays = recruit.getWorkDays();
-        dto.workTime = recruit.getWorkTime();*/
-
-        dto.workDuration = null;
-        dto.workDays = null;
-        dto.workTime = null;
+        dto.workTime = recruit.getWorkTime();
 
         dto.resumeCount = (resumeCount==null)?0L: resumeCount;
 

--- a/src/main/java/com/core/foreign/api/recruit/repository/RecruitRepository.java
+++ b/src/main/java/com/core/foreign/api/recruit/repository/RecruitRepository.java
@@ -10,6 +10,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 import java.util.Optional;
 
 public interface RecruitRepository
@@ -43,6 +45,17 @@ public interface RecruitRepository
     @Query("select r from Recruit r" +
             " where r.employer.id=:employerId and r.recruitPublishStatus='PUBLISHED'")
     Page<Recruit> findPublishedRecruitsByEmployerId(Long employerId, Pageable pageable);
+
+    @Query("select r.id from Recruit r" +
+            " where r.employer.id=:employerId and r.recruitPublishStatus='PUBLISHED'")
+    Page<Long> findPublishedRecruitIdsByEmployerId(Long employerId, Pageable pageable);
+
+    @Query("select r from Recruit r" +
+            " left join fetch r.workDuration" +
+            " left join fetch r.workDays" +
+            " left join fetch r.workTime" +
+            "  where r.id in :ids")
+    List<Recruit> findRecruitsByIds(@Param("ids")List<Long> ids);
 
     // 해당 공고 유형(recruitType)이고 jumpDate가 설정된 공고를 jumpDate 내림차순으로 조회
     @Query("SELECT r FROM Recruit r WHERE r.recruitType = :recruitType AND r.jumpDate IS NOT NULL ORDER BY r.jumpDate DESC")


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #145 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 고용인 신뢰도 계산 추가
- 지연 현황 조회 시 근무 시간, 기간 등 기존 null 로 조회되었던 부분 수정.


## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 공고 엔티티에 값 타입이 있어 지연 현황 시 기존 코드 주석 처리 후 현재  조회 임시 로직 사용


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
![image](https://github.com/user-attachments/assets/6b2ed42e-e61a-4ef9-a44e-246948f48cca)
- 신뢰도 계산은 따로 조회하는 api가 없어 h2로 실행
- 두 값을 이용해 실제 신뢰도 계산하는 로직은 DTO에 정의
![image](https://github.com/user-attachments/assets/418c1f8a-b37c-4f8a-9b7b-ccdea9c96c63)
