### PR TITLE
[FEAT] 회원 탈퇴하기.

### DIFF
--- a/src/main/java/com/core/foreign/api/member/controller/MemberController.java
+++ b/src/main/java/com/core/foreign/api/member/controller/MemberController.java
@@ -936,4 +936,36 @@ public class MemberController {
         return ApiResponse.success(SuccessStatus.APPLICATION_PORTFOLIO_VIEW_SUCCESS, response);
     }
 
+    @Operation(summary = "피고용인 이력서 공개/비공개 변경. API",
+            description = "피고용인 이력서 공개/비공개 변경. API <br>"
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "변경 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+    })
+    @PatchMapping(value = "/employee/resumes/{resume-id}/visibility")
+    public ResponseEntity<ApiResponse<Void>> flipResumePublic(@AuthenticationPrincipal SecurityMember securityMember,
+                                                                                                                           @PathVariable("resume-id") Long resumeId) {
+
+        resumeService.flipResumePublic(securityMember.getId(), resumeId);
+
+        return ApiResponse.success_only(SuccessStatus.RESUME_VISIBILITY_UPDATE_SUCCESS);
+    }
+
+
+    @Operation(summary = "회원 탈퇴하기. API",
+            description = "회원 탈퇴하기. API <br>"
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "탈퇴 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+    })
+    @DeleteMapping(value = "/withdraw")
+    public ResponseEntity<ApiResponse<Void>> withdrawMember(@AuthenticationPrincipal SecurityMember securityMember) {
+
+        memberService.withdrawMember(securityMember.getId());
+
+        return ApiResponse.success_only(SuccessStatus.MEMBER_WITHDRAW_SUCCESS);
+    }
+
 }

--- a/src/main/java/com/core/foreign/api/member/entity/Employer.java
+++ b/src/main/java/com/core/foreign/api/member/entity/Employer.java
@@ -18,11 +18,16 @@ public class Employer extends Member {
     private String companyImageUrl;
 
     private String businessRegistrationNumber; // 사업자등록번호
+    private String archivedBusinessRegistrationNumber;
     private String companyName;                // 회사점포명
+    private String archivedCompanyName;
     private LocalDate establishedDate;         // 설립일
+    private LocalDate archivedEstablishedDate;
 
     private String companyEmail;
+    private String archivedCompanyEmail;
     private String mainPhoneNumber;
+    private String archivedMainPhoneNumber;
 
     @Embedded
     private Address companyAddress;
@@ -55,6 +60,12 @@ public class Employer extends Member {
 
         this.premiumManage = new PremiumManage(this);
         this.companyAddress=address;
+
+        this.archivedBusinessRegistrationNumber=null;
+        this.archivedCompanyName=null;
+        this.archivedEstablishedDate=null;
+        this.archivedCompanyEmail=null;
+        this.archivedMainPhoneNumber=null;
     }
 
     public void updateCompanyEmail(String companyEmail){
@@ -74,6 +85,23 @@ public class Employer extends Member {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
         establishedDate = LocalDate.parse(startDate, formatter);
         updateName(representativeName);
+    }
+
+
+    public void withdraw(){
+        this.archivedBusinessRegistrationNumber=this.businessRegistrationNumber;
+        this.archivedCompanyName=this.companyName;
+        this.archivedEstablishedDate=this.establishedDate;
+        this.archivedCompanyEmail=this.companyEmail;
+        this.archivedMainPhoneNumber=this.mainPhoneNumber;
+
+        this.businessRegistrationNumber=null;
+        this.companyName=null;
+        this.establishedDate=null;
+        this.companyEmail=null;
+        this.mainPhoneNumber=null;
+
+        super.withdraw();
     }
 
 }

--- a/src/main/java/com/core/foreign/api/member/entity/Member.java
+++ b/src/main/java/com/core/foreign/api/member/entity/Member.java
@@ -22,14 +22,19 @@ public abstract class Member extends BaseTimeEntity {
 
     @Column(unique = true)
     private String userId;       // 아이디
+    private String archivedUserId;
     private String password;     // 비밀번호
     private String name;         // 이름[대표자명]
+    private String archivedName;
     @Column(unique = true)
     private String email;        // 이메일
+    private String archivedEmail;
     @Column(unique = true)
     private String phoneNumber;  // 전화번호
+    private String archivedPhoneNumber;
     private String refreshToken; // 리프레시토큰
     private LocalDate birthday;  // 생년월일
+    private LocalDate archivedBirthday;
     private boolean isMale;      // 성별
 
     private boolean termsOfServiceAgreement;
@@ -47,6 +52,8 @@ public abstract class Member extends BaseTimeEntity {
 
     private int evaluationJoinCount;
     private LocalDateTime passwordVerifiedAt;
+    private LocalDateTime withdrawDate;
+    private boolean isWithdrawn;
 
     protected Member(String userId,
                      String password,
@@ -77,6 +84,13 @@ public abstract class Member extends BaseTimeEntity {
         this.adInfoAgreementSnsMms = adInfoAgreementSmsMms;
         this.adInfoAgreementEmail = adInfoAgreementEmail;
         this.evaluationJoinCount = 0;
+        this.archivedUserId=null;
+        this.archivedName=null;
+        this.archivedEmail=null;
+        this.archivedPhoneNumber=null;
+        this.archivedBirthday=null;
+        this.withdrawDate=null;
+        this.isWithdrawn = false;
 
     }
 
@@ -133,6 +147,23 @@ public abstract class Member extends BaseTimeEntity {
 
     public void resetPasswordVerificationTime() {
         this.passwordVerifiedAt = LocalDateTime.now().minusDays(1);
+    }
+
+    public void withdraw(){
+        this.archivedUserId=this.userId;
+        this.archivedName=this.name;
+        this.archivedEmail=this.email;
+        this.archivedPhoneNumber=this.phoneNumber;
+        this.archivedBirthday=this.birthday;
+
+        this.userId=null;
+        this.name=null;
+        this.email=null;
+        this.phoneNumber=null;
+        this.birthday=null;
+
+        this.withdrawDate=LocalDateTime.now();
+        this.isWithdrawn=true;
     }
 
 }

--- a/src/main/java/com/core/foreign/api/member/repository/EmployeeRepository.java
+++ b/src/main/java/com/core/foreign/api/member/repository/EmployeeRepository.java
@@ -13,11 +13,11 @@ import java.util.Optional;
 public interface EmployeeRepository extends JpaRepository<Employee, Long> {
 
     @Query("select e from Employee e" +
-            " where e.isPortfolioPublic=true")
+            " where e.isPortfolioPublic=true and e.isWithdrawn=false")
     Page<Employee> findAllBy(Pageable pageable);
 
     @Query("select e from Employee e" +
-            " where e.id=:employeeId and  e.isPortfolioPublic =true")
+            " where e.id=:employeeId and  e.isPortfolioPublic =true and e.isWithdrawn=false")
     Optional<Employee> findPublicEmployeeById(@Param("employeeId")Long employeeId);
 
     @Modifying

--- a/src/main/java/com/core/foreign/api/recruit/entity/Recruit.java
+++ b/src/main/java/com/core/foreign/api/recruit/entity/Recruit.java
@@ -96,6 +96,8 @@ public abstract class Recruit extends BaseTimeEntity {
 
     protected LocalDateTime jumpDate;
 
+    private boolean isDeleted;
+
     public void jumpNow() {
         this.jumpDate = LocalDateTime.now();
     }
@@ -156,6 +158,7 @@ public abstract class Recruit extends BaseTimeEntity {
         this.posterImageUrl = posterImageUrl;
         this.recruitPublishStatus = recruitPublishStatus;
         this.jumpDate = jumpDate;
+        this.isDeleted=false;
     }
 
 

--- a/src/main/java/com/core/foreign/api/recruit/entity/Resume.java
+++ b/src/main/java/com/core/foreign/api/recruit/entity/Resume.java
@@ -94,4 +94,13 @@ public class Resume {
         this.contractStatus = ContractStatus.COMPLETED;
         this.contractCompletionDate = contractCompletionDate;
     }
+
+    public void flipPublic(){
+        if(this.isPublic){
+            this.isPublic=false;
+        }
+        else{
+            this.isPublic=true;
+        }
+    }
 }

--- a/src/main/java/com/core/foreign/api/recruit/repository/RecruitRepository.java
+++ b/src/main/java/com/core/foreign/api/recruit/repository/RecruitRepository.java
@@ -5,10 +5,7 @@ import com.core.foreign.api.recruit.entity.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.data.jpa.repository.EntityGraph;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.*;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
@@ -39,7 +36,7 @@ public interface RecruitRepository
             "left join fetch r.workTime " +
             "left join fetch r.workDays " +
             "join fetch r.employer " +
-            "where r.id = :recruitId")
+            "where r.id = :recruitId and r.isDeleted=false")
     Optional<Recruit> findByIdFetchJoin(@Param("recruitId") Long recruitId);
 
     @Query("select r from Recruit r" +
@@ -54,7 +51,7 @@ public interface RecruitRepository
             " left join fetch r.workDuration" +
             " left join fetch r.workDays" +
             " left join fetch r.workTime" +
-            "  where r.id in :ids")
+            " where r.id in :ids")
     List<Recruit> findRecruitsByIds(@Param("ids")List<Long> ids);
 
     // 해당 공고 유형(recruitType)이고 jumpDate가 설정된 공고를 jumpDate 내림차순으로 조회
@@ -76,5 +73,9 @@ public interface RecruitRepository
     }
 
     boolean existsByEmployerAndRecruitPublishStatus(Member employer, RecruitPublishStatus status);
+
+    @Modifying
+    @Query("update Recruit r set r.isDeleted=true where r.employer.id=:employerId")
+    void softDeleteByEmployerId(@Param("employerId") Long employerId);
 
 }

--- a/src/main/java/com/core/foreign/api/recruit/repository/ResumeRepository.java
+++ b/src/main/java/com/core/foreign/api/recruit/repository/ResumeRepository.java
@@ -67,11 +67,15 @@ public interface ResumeRepository extends JpaRepository<Resume, Long>, ResumeRep
 
     @Query("select r from Resume r" +
             " join fetch r.recruit" +
-            " where r.recruitmentStatus='APPROVED' and r.isEmployerEvaluatedByEmployee= :evaluationStatus")
+            " where r.recruitmentStatus='APPROVED' and r.isDeleted=false and r.isEmployerEvaluatedByEmployee= :evaluationStatus")
     Page<Resume> findResumeByEmployeeIdAndEvaluationStatus(@Param("employeeId")Long employeeId,  @Param("evaluationStatus") EvaluationStatus evaluationStatus, Pageable pageable);
 
     @Modifying
     @Query("update Resume resume set resume.viewCount=resume.viewCount+1 where resume.id=:resumeId")
     void increaseViewCount(@Param("resumeId") Long resumeId);
+
+    @Modifying
+    @Query("update Resume r set r.isDeleted=true where r.employee.id=:employeeId")
+    void softDeleteByEmployeeId(@Param("employeeId") Long employeeId);
 
 }

--- a/src/main/java/com/core/foreign/api/recruit/repository/ResumeRepositoryImpl.java
+++ b/src/main/java/com/core/foreign/api/recruit/repository/ResumeRepositoryImpl.java
@@ -30,9 +30,9 @@ public class ResumeRepositoryImpl implements ResumeRepositoryQueryDSL{
     }
 
     @Override
-    public Page<Resume> searchResumedByRecruitId(Long recruitId,
-                                          String keyword, RecruitmentStatus recruitmentStatus, ContractStatus contractStatus,
-                                          Pageable pageable) {
+    public Page<Resume> searchResumeByRecruitId(Long recruitId,
+                                                String keyword, RecruitmentStatus recruitmentStatus, ContractStatus contractStatus,
+                                                Pageable pageable) {
 
         if(keyword==null){
             keyword="";
@@ -66,9 +66,6 @@ public class ResumeRepositoryImpl implements ResumeRepositoryQueryDSL{
 
                 );
 
-
-
-
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
 
     }
@@ -85,7 +82,8 @@ public class ResumeRepositoryImpl implements ResumeRepositoryQueryDSL{
                 .innerJoin(recruit.businessFields)
                 .where(
                         isPublic(),
-                        businessFieldEq(businessField) // 특정 비즈니스 필드에 대한 필터링
+                        businessFieldEq(businessField), // 특정 비즈니스 필드에 대한 필터링
+                        resume.isDeleted.eq(false)
                 )
                 .orderBy(resume.id.desc()) // 최신순 정렬
                 .offset(pageable.getOffset())

--- a/src/main/java/com/core/foreign/api/recruit/repository/ResumeRepositoryQueryDSL.java
+++ b/src/main/java/com/core/foreign/api/recruit/repository/ResumeRepositoryQueryDSL.java
@@ -10,9 +10,9 @@ import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface ResumeRepositoryQueryDSL {
-    Page<Resume> searchResumedByRecruitId(Long recruitId,
-                                          String keyword, RecruitmentStatus recruitmentStatus, ContractStatus contractStatus,
-                                          Pageable pageable);
+    Page<Resume> searchResumeByRecruitId(Long recruitId,
+                                         String keyword, RecruitmentStatus recruitmentStatus, ContractStatus contractStatus,
+                                         Pageable pageable);
 
     Page<Resume> getApplicationPortfolio(List<BusinessField> businessField, Pageable pageable);
 }

--- a/src/main/java/com/core/foreign/api/recruit/service/RecruitDeleter.java
+++ b/src/main/java/com/core/foreign/api/recruit/service/RecruitDeleter.java
@@ -1,0 +1,19 @@
+package com.core.foreign.api.recruit.service;
+
+import com.core.foreign.api.recruit.repository.RecruitRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RecruitDeleter {
+    private final RecruitRepository recruitRepository;
+
+    @Transactional
+    public void deleteRecruitOnEmployeeWithdrawal(Long employerId){
+        recruitRepository.softDeleteByEmployerId(employerId);
+    }
+}

--- a/src/main/java/com/core/foreign/api/recruit/service/RecruitService.java
+++ b/src/main/java/com/core/foreign/api/recruit/service/RecruitService.java
@@ -960,6 +960,4 @@ public class RecruitService {
         return PageResponseDTO.of(dtoPage);
     }
 
-
-
 }

--- a/src/main/java/com/core/foreign/api/recruit/service/ResumeDeleter.java
+++ b/src/main/java/com/core/foreign/api/recruit/service/ResumeDeleter.java
@@ -1,0 +1,19 @@
+package com.core.foreign.api.recruit.service;
+
+import com.core.foreign.api.recruit.repository.ResumeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ResumeDeleter {
+    private final ResumeRepository resumeRepository;
+
+    @Transactional
+    public void deleteResumeOnEmployeeWithdrawal(Long employeeId){
+        resumeRepository.softDeleteByEmployeeId(employeeId);
+    }
+}

--- a/src/main/java/com/core/foreign/api/recruit/service/ResumeReader.java
+++ b/src/main/java/com/core/foreign/api/recruit/service/ResumeReader.java
@@ -70,7 +70,7 @@ public class ResumeReader {
                                                                                         Integer page, Integer size) {
         Pageable pageable = PageRequest.of(page, size);
 
-        Page<Resume> resumes = resumeRepository.searchResumedByRecruitId(recruitId, keyword, recruitmentStatus, contractStatus, pageable);
+        Page<Resume> resumes = resumeRepository.searchResumeByRecruitId(recruitId, keyword, recruitmentStatus, contractStatus, pageable);
         Page<ApplicationResumePreviewResponseDTO> dto = resumes.map(ApplicationResumePreviewResponseDTO::from);
 
         PageResponseDTO<ApplicationResumePreviewResponseDTO> response = PageResponseDTO.of(dto);

--- a/src/main/java/com/core/foreign/api/recruit/service/ResumeService.java
+++ b/src/main/java/com/core/foreign/api/recruit/service/ResumeService.java
@@ -319,6 +319,9 @@ public class ResumeService {
             throw new BadRequestException(UNAUTHORIZED_RESUME_DELETE_EXCEPTION.getMessage());
         }
 
+        /**
+         * 모집 승인된 거 어떻게 처리해야 하지.
+         */
 
         resume.delete();
     }
@@ -332,6 +335,25 @@ public class ResumeService {
         PageResponseDTO<TagResponseDTO> response = resumeReader.getTags(employerId, evaluationStatus, page, size);
 
         return response;
+    }
+
+    @Transactional
+    public void flipResumePublic(Long employeeId, Long resumeId){
+        Resume resume = resumeRepository.findById(resumeId)
+                .orElseThrow(() -> {
+                    log.warn("[flipResumePublic][resume not found][resumeId= {}]", resumeId);
+                    return new BadRequestException(RESUME_NOT_FOUND_EXCEPTION.getMessage());
+                });
+
+        Employee employee = resume.getEmployee();
+
+        if(!Objects.equals(employeeId, employee.getId())){
+            log.warn("[flipResumePublic][다른 사람 이력서 공개/비공개 변경 시도][requestEmployerId= {}, employerIdOfResume= {}]", employeeId, employee.getId());
+            throw new BadRequestException(INVALID_RESUME_OWNER_EXCEPTION.getMessage());
+        }
+
+        resume.flipPublic();
+
     }
 
 }

--- a/src/main/java/com/core/foreign/common/response/ErrorStatus.java
+++ b/src/main/java/com/core/foreign/common/response/ErrorStatus.java
@@ -72,6 +72,7 @@ public enum ErrorStatus {
     REQUIRED_TERMS_NOT_AGREED_EXCEPTION(HttpStatus.BAD_REQUEST, "필수 약관에 동의하지 않았습니다."),
     TEMPORARY_RECRUIT_APPLICATION_NOT_ALLOWED_EXCEPTION(HttpStatus.BAD_REQUEST, "임시 저장 공고는 지원이 불가합니다."),
     INVALID_CONTRACT_OWNER_EXCEPTION(HttpStatus.BAD_REQUEST, "계약서 소유자가 아닙니다."),
+    INVALID_RESUME_OWNER_EXCEPTION(HttpStatus.BAD_REQUEST, "이력서 소유자가 아닙니다."),
 
     /**
      * 401 UNAUTHORIZED

--- a/src/main/java/com/core/foreign/common/response/SuccessStatus.java
+++ b/src/main/java/com/core/foreign/common/response/SuccessStatus.java
@@ -75,6 +75,9 @@ public enum SuccessStatus {
     SEND_TOP_JUMP_COUNT_SUCCESS(HttpStatus.OK,"상단 점프 잔여 횟수 조회 성공"),
     ALBA_REVIEW_SEARCH_SUCCESS(HttpStatus.OK, "알바 후기 검색 성공"),
     SEARCH_RECRUIT_SUCESS(HttpStatus.OK,"공고 검색 성공"),
+    RESUME_VISIBILITY_UPDATE_SUCCESS(HttpStatus.OK, "이력서 공개 상태 변경 성공"),
+    MEMBER_WITHDRAW_SUCCESS(HttpStatus.OK, "회원 탈퇴 성공"),
+
 
     /**
      * 201


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #156 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 회원 탈퇴 시 공고 및 이력서 삭제.
- 회원 탈퇴해도 계약서 유지해야 하기 때문에 전부 논리 삭제.
- 탈퇴하였어도 해당 계약서를 누가 작성했는지 알 수 있어야 함.
- 식별을 위해 번호, 이메일 등을 사용할 수 있지만, 해당 칼럼은 유니크 제약 조건이 있어 남겨둘 수 없어 다른 필드를 추가하여 유지.
- 피고용인 이력서 공개/비공개 기능 추가
- 피고용인이 이력서 삭제 시 모집이 승인되었다면 ,추가 작업이 필요해보여 회의 후 추가 진행.


## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
- 이력서 공개/비공개 변경
![이력서 공개 상태 변경 성공](https://github.com/user-attachments/assets/c377fe5c-fc3b-4dc6-8715-f42303032bbc)
- 탈퇴 전 이력서 및 공고 조회 성공
![탈퇴 전 공고 조회 성공](https://github.com/user-attachments/assets/a47442a7-6cdb-41c7-ace3-23a2f6692fdb)
![탈퇴 전 이력서 조회 성공](https://github.com/user-attachments/assets/0873cdb9-84d9-4a1b-9aa6-336458b00a3c)
-탈퇴
![탈퇴 성공](https://github.com/user-attachments/assets/ac69c5dc-475f-4a17-9b33-6cf21f651ab3)
- 탈퇴 후 조회 불가.
![피고용인 탈퇴 후 이력서 조회 안 됨](https://github.com/user-attachments/assets/2eae164b-bb67-4dbd-b15a-7cbf218e90cb)
![고용인 탈퇴 후 공고 조회 안 됨](https://github.com/user-attachments/assets/8fff59a8-007e-41f6-b704-23c57787d851)

