### PR TITLE
[FIX] 공고 조회 급여 필터 리스트화

### DIFF
--- a/src/main/java/com/core/foreign/api/recruit/controller/RecruitController.java
+++ b/src/main/java/com/core/foreign/api/recruit/controller/RecruitController.java
@@ -669,7 +669,7 @@ public class RecruitController {
             @RequestParam(required = false) List<String> workDays,
             @RequestParam(required = false) List<String> workTimes,
             @RequestParam(required = false) String gender,
-            @RequestParam(required = false) String salaryType
+            @RequestParam(required = false) List<String> salaryType
     ) {
         // 검색조건 생성
         RecruitSearchConditionDTO condition = RecruitSearchConditionDTO.builder()
@@ -706,7 +706,7 @@ public class RecruitController {
             @RequestParam(required = false) List<String> workDays,
             @RequestParam(required = false) List<String> workTimes,
             @RequestParam(required = false) String gender,
-            @RequestParam(required = false) String salaryType
+            @RequestParam(required = false) List<String> salaryType
     ) {
         // 검색조건 생성
         RecruitSearchConditionDTO condition = RecruitSearchConditionDTO.builder()

--- a/src/main/java/com/core/foreign/api/recruit/dto/RecruitSearchConditionDTO.java
+++ b/src/main/java/com/core/foreign/api/recruit/dto/RecruitSearchConditionDTO.java
@@ -21,5 +21,5 @@ public class RecruitSearchConditionDTO {
     private List<String> workDays;        // 근무요일 (최대 3개)
     private List<String> workTimes;       // 근무시간 (최대 3개)
     private String gender;                         // 성별 (남자, 여자, null=무관)
-    private String salaryType;                     // 급여형태 (시급, 월급, 연봉 등)
+    private List<String> salaryType;                     // 급여형태 (시급, 월급, 연봉 등)
 }

--- a/src/main/java/com/core/foreign/api/recruit/service/RecruitService.java
+++ b/src/main/java/com/core/foreign/api/recruit/service/RecruitService.java
@@ -503,7 +503,7 @@ public class RecruitService {
                         (condition.getWorkDays() != null && !condition.getWorkDays().isEmpty()) ||
                         (condition.getWorkTimes() != null && !condition.getWorkTimes().isEmpty()) ||
                         (condition.getGender() != null && !condition.getGender().trim().isEmpty()) ||
-                        (condition.getSalaryType() != null && !condition.getSalaryType().trim().isEmpty());
+                        (condition.getSalaryType() != null && !condition.getSalaryType().isEmpty());
 
         // 페이징 객체 생성: 필터가 적용되면 createdAt 내림차순 정렬, 그렇지 않으면 정렬 없이 Specification에서 커스텀 정렬 적용
         Pageable pageable;
@@ -522,7 +522,7 @@ public class RecruitService {
             predicate = cb.and(predicate, RecruitSpecifications.workDaysIn(condition.getWorkDays()).toPredicate(root, query, cb));
             predicate = cb.and(predicate, RecruitSpecifications.workTimeIn(condition.getWorkTimes()).toPredicate(root, query, cb));
             predicate = cb.and(predicate, RecruitSpecifications.genderEq(condition.getGender()).toPredicate(root, query, cb));
-            predicate = cb.and(predicate, RecruitSpecifications.salaryTypeEq(condition.getSalaryType()).toPredicate(root, query, cb));
+            predicate = cb.and(predicate, RecruitSpecifications.salaryTypeIn(condition.getSalaryType()).toPredicate(root, query, cb));
 
             // 필터 조건이 없는 경우에만 커스텀 정렬 적용
             if (!isFilterApplied && query.getOrderList().isEmpty()) {
@@ -601,7 +601,7 @@ public class RecruitService {
                         (condition.getWorkDays() != null && !condition.getWorkDays().isEmpty()) ||
                         (condition.getWorkTimes() != null && !condition.getWorkTimes().isEmpty()) ||
                         (condition.getGender() != null && !condition.getGender().trim().isEmpty()) ||
-                        (condition.getSalaryType() != null && !condition.getSalaryType().trim().isEmpty());
+                        (condition.getSalaryType() != null && !condition.getSalaryType().isEmpty());
 
         Pageable pageable;
         if (!isFilterApplied) {
@@ -618,7 +618,7 @@ public class RecruitService {
                     .and(RecruitSpecifications.workDaysIn(condition.getWorkDays()))
                     .and(RecruitSpecifications.workTimeIn(condition.getWorkTimes()))
                     .and(RecruitSpecifications.genderEq(condition.getGender()))
-                    .and(RecruitSpecifications.salaryTypeEq(condition.getSalaryType()))
+                    .and(RecruitSpecifications.salaryTypeIn(condition.getSalaryType()))
                     .toPredicate(root, query, cb);
 
             // 필터 조건이 없으면 커스텀 정렬 로직 적용

--- a/src/main/java/com/core/foreign/api/recruit/service/RecruitService.java
+++ b/src/main/java/com/core/foreign/api/recruit/service/RecruitService.java
@@ -516,6 +516,7 @@ public class RecruitService {
         Specification<Recruit> spec = (root, query, cb) -> {
             // 기본 조건 : PUBLISHED 상태여야 함
             Predicate predicate = cb.conjunction();
+            predicate = cb.and(predicate, cb.equal(root.get("isDeleted"), false));
             predicate = cb.and(predicate, RecruitSpecifications.isPublished().toPredicate(root, query, cb));
             predicate = cb.and(predicate, RecruitSpecifications.businessFieldsIn(condition.getBusinessFields()).toPredicate(root, query, cb));
             predicate = cb.and(predicate, RecruitSpecifications.workDurationIn(condition.getWorkDurations()).toPredicate(root, query, cb));
@@ -612,6 +613,7 @@ public class RecruitService {
 
         Specification<Recruit> spec = (root, query, cb) -> {
             Predicate p = Specification.where(RecruitSpecifications.isPremium())
+                    .and((root1, query1, cb1) -> cb.equal(root1.get("isDeleted"), false))
                     .and(RecruitSpecifications.isPublished())
                     .and(RecruitSpecifications.businessFieldsIn(condition.getBusinessFields()))
                     .and(RecruitSpecifications.workDurationIn(condition.getWorkDurations()))

--- a/src/main/java/com/core/foreign/api/recruit/service/RecruitSpecifications.java
+++ b/src/main/java/com/core/foreign/api/recruit/service/RecruitSpecifications.java
@@ -91,12 +91,17 @@ public class RecruitSpecifications {
     }
 
     // 급여형태 필터
-    public static Specification<Recruit> salaryTypeEq(String salaryType) {
+    public static Specification<Recruit> salaryTypeIn(List<String> salaryTypes) {
         return (root, query, cb) -> {
-            if (salaryType == null || salaryType.trim().isEmpty()) {
+            if (salaryTypes == null || salaryTypes.isEmpty()) {
                 return cb.conjunction();
             }
-            return cb.equal(root.get("salaryType"), salaryType);
+            Expression<String> salaryTypeExp = root.get("salaryType");
+            Predicate predicate = cb.disjunction();
+            for (String type : salaryTypes) {
+                predicate = cb.or(predicate, cb.equal(salaryTypeExp, type));
+            }
+            return predicate;
         };
     }
 


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #158

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 공고 전체 조회, 프리미엄 전체 공고 조회 API에서 급여 필터링을 단일 이 아닌 리스트로 받을 수 있도록 수정하였습니다. 
- 공고 전체 조회, 프리미엄 전체 공고 조회 API에서 삭제된 공고는 조회되지 않도록 수정하였습니다.


## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
[ 프리미엄 공고 전체 조회 ] 
![image](https://github.com/user-attachments/assets/535e477b-7ac2-4fd1-8da1-c0013f5a130a)

[ 공고 전체 조회 ] 
![image](https://github.com/user-attachments/assets/1bf882fa-50d9-4b2e-9218-8b5460ecac5b)
