### PR TITLE
[FIX] 포트폴리오 조회 시 로그인 유무에 따라 다르게 처리.

### DIFF
--- a/src/main/java/com/core/foreign/api/member/controller/MemberController.java
+++ b/src/main/java/com/core/foreign/api/member/controller/MemberController.java
@@ -12,6 +12,7 @@ import com.core.foreign.api.member.jwt.service.JwtService;
 import com.core.foreign.api.member.service.*;
 import com.core.foreign.api.portfolio.dto.response.ApplicationPortfolioPreviewResponseDTO;
 import com.core.foreign.api.portfolio.dto.response.BasicPortfolioPreviewResponseDTO;
+import com.core.foreign.api.recruit.dto.MyResumeResponseDTO;
 import com.core.foreign.api.recruit.dto.PageResponseDTO;
 import com.core.foreign.api.recruit.dto.RecruitPreviewResponseDTO;
 import com.core.foreign.api.recruit.entity.EvaluationStatus;
@@ -966,6 +967,22 @@ public class MemberController {
         memberService.withdrawMember(securityMember.getId());
 
         return ApiResponse.success_only(SuccessStatus.MEMBER_WITHDRAW_SUCCESS);
+    }
+
+    @Operation(summary = "마이페이지(피고용인) 이력서 조회. API",
+            description = "마이페이지(피고용인) 이력서 조회. <br>"
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+    })
+    @GetMapping(value = "/employee/my-resumes/{resume-id}")
+    public ResponseEntity<ApiResponse<MyResumeResponseDTO>> getMyResume(@AuthenticationPrincipal SecurityMember securityMember,
+                                                         @PathVariable("resume-id")Long resumeId) {
+
+        MyResumeResponseDTO myResume = memberService.getMyResume(securityMember.getId(), resumeId);
+
+        return ApiResponse.success(SuccessStatus.SEND_MY_RESUME_SUCCESS, myResume);
     }
 
 }

--- a/src/main/java/com/core/foreign/api/member/dto/EmployeePortfolioDTO.java
+++ b/src/main/java/com/core/foreign/api/member/dto/EmployeePortfolioDTO.java
@@ -22,7 +22,6 @@ public class EmployeePortfolioDTO {
     private String englishTestType;
     private int englishTestScore; // 점수
 
-
     private List<EmployeePortfolioExperienceDTO> experiences;
     private List<EmployeePortfolioCertificationDTO> certifications;
     private List<EmployeePortfolioAwardDTO> awards;
@@ -64,6 +63,41 @@ public class EmployeePortfolioDTO {
 
     }
 
+    public static EmployeePortfolioDTO from(EmployeePortfolio portfolio) {
+        if(portfolio == null) {return null;}
+
+        EmployeePortfolioDTO dto = new EmployeePortfolioDTO();
+        dto.introduction = portfolio.getIntroduction();
+        dto.enrollmentCertificateUrl = portfolio.getEnrollmentCertificateUrl();
+        dto.transcriptUrl = portfolio.getTranscriptUrl();
+        dto.partTimeWorkPermitUrl = portfolio.getPartTimeWorkPermitUrl();
+        dto.topic = portfolio.getTopic();
+        dto.englishTestType = portfolio.getEnglishTestType();
+        dto.englishTestScore = portfolio.getEnglishTestScore();
+
+
+        List<EmployeePortfolioExperienceDTO> e = new ArrayList<>();
+        List<EmployeePortfolioCertificationDTO> c = new ArrayList<>();
+        List<EmployeePortfolioAwardDTO> a = new ArrayList<>();
+
+        List<EmployeePortfolioBusinessFieldInfo> infos = portfolio.getEmployeePortfolioBusinessFieldInfos();
+        for (EmployeePortfolioBusinessFieldInfo info : infos) {
+            if (info.getEmployeePortfolioBusinessFieldType() == EmployeePortfolioBusinessFieldType.EXPERIENCE) {
+                e.add(EmployeePortfolioExperienceDTO.from(info));
+            } else if (info.getEmployeePortfolioBusinessFieldType() == EmployeePortfolioBusinessFieldType.CERTIFICATION) {
+                c.add(EmployeePortfolioCertificationDTO.from(info));
+            } else if (info.getEmployeePortfolioBusinessFieldType() == EmployeePortfolioBusinessFieldType.AWARD) {
+                a.add(EmployeePortfolioAwardDTO.from(info));
+            }
+        }
+
+        dto.experiences = e;
+        dto.certifications = c;
+        dto.awards = a;
+
+        return dto;
+    }
+
     public static EmployeePortfolioDTO from(BasicPortfolioDTO basicPortfolio){
         EmployeePortfolioDTO dto = new EmployeePortfolioDTO();
         dto.introduction = basicPortfolio.getIntroduction();
@@ -77,7 +111,6 @@ public class EmployeePortfolioDTO {
         dto.experiences=basicPortfolio.getExperiences();
         dto.certifications=basicPortfolio.getCertifications();
         dto.awards=basicPortfolio.getAwards();
-
 
         return dto;
     }

--- a/src/main/java/com/core/foreign/api/member/entity/EmployerEmployee.java
+++ b/src/main/java/com/core/foreign/api/member/entity/EmployerEmployee.java
@@ -1,7 +1,6 @@
 package com.core.foreign.api.member.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/core/foreign/api/member/repository/EmployeePortfolioRepository.java
+++ b/src/main/java/com/core/foreign/api/member/repository/EmployeePortfolioRepository.java
@@ -16,6 +16,11 @@ public interface EmployeePortfolioRepository extends JpaRepository<EmployeePortf
             " where p.employee.id=:employeeId and p.employeePortfolioStatus=:status")
     Optional<EmployeePortfolio> findByEmployeeId(@Param("employeeId")Long employeeId, @Param("status") EmployeePortfolioStatus status);
 
+    @Query("select p from EmployeePortfolio p" +
+            " left join fetch p.employeePortfolioBusinessFieldInfos" +
+            " where p.employee.id=:employeeId and p.employeePortfolioStatus=:status")
+    Optional<EmployeePortfolio> findEmployeePortfolioByEmployeeIdAndEmployeePortfolioStatus(@Param("employeeId")Long employeeId, @Param("status") EmployeePortfolioStatus status);
+
     @Query("select count(*)>0 from EmployeePortfolio p" +
             " where p.employee.id=:employeeId and p.employeePortfolioStatus=:status")
     boolean existsByEmployeeId(@Param("employeeId")Long employeeId, @Param("status") EmployeePortfolioStatus status);

--- a/src/main/java/com/core/foreign/api/portfolio/controller/PortfolioController.java
+++ b/src/main/java/com/core/foreign/api/portfolio/controller/PortfolioController.java
@@ -54,7 +54,10 @@ public class PortfolioController {
     @GetMapping(value = "/basics/{employee-id}")
     public ResponseEntity<ApiResponse<BasicPortfolioResponseDTO>> getBasicPortfolio(@AuthenticationPrincipal SecurityMember securityMember,
                                                                                     @PathVariable("employee-id") Long employeeId) {
-        BasicPortfolioResponseDTO basicPortfolio = portfolioService.getBasicPortfolio(securityMember.getId(), employeeId);
+
+        Long memberId=securityMember!=null?securityMember.getId():null;
+
+        BasicPortfolioResponseDTO basicPortfolio = portfolioService.getBasicPortfolio(memberId, employeeId);
 
         return ApiResponse.success(SuccessStatus.BASIC_PORTFOLIO_VIEW_SUCCESS, basicPortfolio);
     }
@@ -87,7 +90,10 @@ public class PortfolioController {
     @GetMapping(value = "/applications/{resume-id}")
     public ResponseEntity<ApiResponse<ApplicationPortfolioResponseDTO>> getApplicationPortfolio(@AuthenticationPrincipal SecurityMember securityMember,
                                                                                                 @PathVariable("resume-id") Long resumeId) {
-        ApplicationPortfolioResponseDTO applicationPortfolio = portfolioService.getApplicationPortfolio(securityMember.getId(), resumeId);
+
+        Long memberId=securityMember!=null?securityMember.getId():null;
+
+        ApplicationPortfolioResponseDTO applicationPortfolio = portfolioService.getApplicationPortfolio(memberId, resumeId);
 
         return ApiResponse.success(SuccessStatus.APPLICATION_PORTFOLIO_VIEW_SUCCESS, applicationPortfolio);
     }

--- a/src/main/java/com/core/foreign/api/recruit/controller/RecruitController.java
+++ b/src/main/java/com/core/foreign/api/recruit/controller/RecruitController.java
@@ -780,7 +780,7 @@ public class RecruitController {
     @GetMapping(value = "/resumes/{resume-id}")
     public ResponseEntity<ApiResponse<ApplicationResumeResponseDTO>> getResume(@AuthenticationPrincipal SecurityMember securityMember,
                                                                                @PathVariable("resume-id") Long resumeId) {
-        ApplicationResumeResponseDTO resume = resumeService.getResume(securityMember.getId(), resumeId);
+        ApplicationResumeResponseDTO resume = resumeService.getResumeForEmployer(resumeId);
         return ApiResponse.success(SuccessStatus.SEND_APPLICANT_RESUME_SUCCESS, resume);
     }
 

--- a/src/main/java/com/core/foreign/api/recruit/dto/ApplicationResumeResponseDTO.java
+++ b/src/main/java/com/core/foreign/api/recruit/dto/ApplicationResumeResponseDTO.java
@@ -1,55 +1,94 @@
 package com.core.foreign.api.recruit.dto;
 
-import com.core.foreign.api.member.dto.EmployeeBasicResumeResponseDTO;
-import com.core.foreign.api.member.dto.EmployeePortfolioDTO;
-import com.core.foreign.api.member.entity.Role;
 import com.core.foreign.api.contract.entity.ContractStatus;
+import com.core.foreign.api.member.dto.EmployeePortfolioAwardDTO;
+import com.core.foreign.api.member.dto.EmployeePortfolioCertificationDTO;
+import com.core.foreign.api.member.dto.EmployeePortfolioDTO;
+import com.core.foreign.api.member.dto.EmployeePortfolioExperienceDTO;
+import com.core.foreign.api.member.entity.Address;
+import com.core.foreign.api.member.entity.Employee;
+import com.core.foreign.api.member.entity.Topic;
+import com.core.foreign.api.recruit.dto.internal.ResumeDTO;
 import com.core.foreign.api.recruit.entity.EvaluationStatus;
 import com.core.foreign.api.recruit.entity.RecruitmentStatus;
-import com.core.foreign.api.recruit.entity.Resume;
 import lombok.Getter;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Getter
 public class ApplicationResumeResponseDTO {
     private Long resumeId;
-    private EmployeeBasicResumeResponseDTO employeeBasicResumeResponseDTO;
-    private EmployeePortfolioDTO employeePortfolioDTO;
+    private Long employeeId;
+
+    private String name;
+    private String nationality;
+    private String education;
+    private String visa;
+    private LocalDate birthDate;
+    private String email;
+    private String phoneNumber;
+    private String zipcode;
+    private String address1;
+    private String address2;
+
+    private String introduction; // 자기소개
+    private String enrollmentCertificateUrl; // 재학증명서
+    private String transcriptUrl; // 성적증명서
+    private String partTimeWorkPermitUrl; // 시간제근로허가서
+    private Topic topic;
+    private String englishTestType;
+    private int englishTestScore; // 점수
+    private List<EmployeePortfolioExperienceDTO> experiences;
+    private List<EmployeePortfolioCertificationDTO> certifications;
+    private List<EmployeePortfolioAwardDTO> awards;
+
     private String messageToEmployer;
+
     private List<ResumePortfolioTextResponseDTO> texts;
     private List<ResumePortfolioFileResponseDTO> files;
 
-    private Role role;
     private RecruitmentStatus recruitmentStatus;
     private ContractStatus contractStatus;
     private EvaluationStatus isEmployeeEvaluatedByEmployer; // 고용인이 피고용인을 평가했는지 여부
 
-    private boolean isPublic;
 
-    public ApplicationResumeResponseDTO(Resume resume, EmployeeBasicResumeResponseDTO employeeBasicResumeResponseDTO,
-                                        EmployeePortfolioDTO employeePortfolioDTO,
-                                        String messageToEmployer, List<ResumePortfolioTextResponseDTO> texts, List<ResumePortfolioFileResponseDTO> files) {
-        this.resumeId = resume.getId();
-        this.employeeBasicResumeResponseDTO = employeeBasicResumeResponseDTO;
-        this.employeePortfolioDTO = employeePortfolioDTO;
-        this.messageToEmployer = messageToEmployer;
-        this.texts = texts;
-        this.files = files;
+   public static ApplicationResumeResponseDTO of(ResumeDTO resume, Employee employee, EmployeePortfolioDTO employeePortfolioDTO){
+       ApplicationResumeResponseDTO dto = new ApplicationResumeResponseDTO();
 
-        this.isEmployeeEvaluatedByEmployer = resume.getIsEmployeeEvaluatedByEmployer();
-        this.contractStatus = resume.getContractStatus();
-        this.recruitmentStatus = resume.getRecruitmentStatus();
+       Address address = employee.getAddress();
 
-        this.isPublic = resume.isPublic();
-    }
+       dto.resumeId = resume.getResumeId();
+       dto.employeeId = employee.getId();
+       dto.name = employee.getName();
+       dto.nationality = employee.getNationality();
+       dto.education = employee.getEducation();
+       dto.visa = employee.getVisa();
+       dto.birthDate = employee.getBirthday();
+       dto.email = employee.getEmail();
+       dto.phoneNumber = employee.getPhoneNumber();
+       dto.zipcode = address.getZipcode();
+       dto.address1 = address.getAddress1();
+       dto.address2 = address.getAddress2();
+       dto.introduction = employeePortfolioDTO.getIntroduction();
+       dto.enrollmentCertificateUrl = employeePortfolioDTO.getEnrollmentCertificateUrl();
+       dto.transcriptUrl = employeePortfolioDTO.getTranscriptUrl();
+       dto.partTimeWorkPermitUrl=employeePortfolioDTO.getPartTimeWorkPermitUrl();
+       dto.topic=employeePortfolioDTO.getTopic();
+       dto.englishTestType=employeePortfolioDTO.getEnglishTestType();
+       dto.englishTestScore=employeePortfolioDTO.getEnglishTestScore();
+       dto.experiences=employeePortfolioDTO.getExperiences();
+       dto.certifications=employeePortfolioDTO.getCertifications();
+       dto.awards=employeePortfolioDTO.getAwards();
+       dto.messageToEmployer=resume.getMessageToEmployer();
+       dto.texts=resume.getTexts();
+       dto.files=resume.getFiles();
+       dto.recruitmentStatus=resume.getRecruitmentStatus();
+       dto.contractStatus=resume.getContractStatus();
+       dto.isEmployeeEvaluatedByEmployer=resume.getIsEmployeeEvaluatedByEmployer();
 
+       return dto;
 
-    public void setRole(Role role) {
-        this.role = role;
-    }
+   }
 
-    public Long getEmployeeId(){
-        return employeeBasicResumeResponseDTO.getEmployeeId();
-    }
 }

--- a/src/main/java/com/core/foreign/api/recruit/dto/MyResumeResponseDTO.java
+++ b/src/main/java/com/core/foreign/api/recruit/dto/MyResumeResponseDTO.java
@@ -1,0 +1,86 @@
+package com.core.foreign.api.recruit.dto;
+
+import com.core.foreign.api.member.dto.EmployeePortfolioAwardDTO;
+import com.core.foreign.api.member.dto.EmployeePortfolioCertificationDTO;
+import com.core.foreign.api.member.dto.EmployeePortfolioDTO;
+import com.core.foreign.api.member.dto.EmployeePortfolioExperienceDTO;
+import com.core.foreign.api.member.entity.Address;
+import com.core.foreign.api.member.entity.Employee;
+import com.core.foreign.api.member.entity.Topic;
+import com.core.foreign.api.recruit.dto.internal.ResumeDTO;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class MyResumeResponseDTO {
+    private Long resumeId;
+
+    private String name;
+    private String nationality;
+    private LocalDate birthDate;
+    private String email;
+    private String phoneNumber;
+    private String zipcode;
+    private String address1;
+    private String address2;
+
+    private String introduction; // 자기소개
+    private String enrollmentCertificateUrl; // 재학증명서
+    private String transcriptUrl; // 성적증명서
+    private String partTimeWorkPermitUrl; // 시간제근로허가서
+    private Topic topic;
+    private String englishTestType;
+    private int englishTestScore; // 점수
+    private List<EmployeePortfolioExperienceDTO> experiences;
+    private List<EmployeePortfolioCertificationDTO> certifications;
+    private List<EmployeePortfolioAwardDTO> awards;
+
+    private List<ResumePortfolioTextResponseDTO> texts;
+    private List<ResumePortfolioFileResponseDTO> files;
+
+    private boolean portfolioPublic;
+
+
+    public static MyResumeResponseDTO of(Employee employee, EmployeePortfolioDTO employeePortfolio, ResumeDTO resumeDTO) {
+        MyResumeResponseDTO dto = new MyResumeResponseDTO();
+
+        Address address = employee.getAddress();
+
+        dto.resumeId = resumeDTO.getResumeId();
+        dto.name = employee.getName();
+        dto.nationality = employee.getNationality();
+        dto.birthDate = employee.getBirthday();
+        dto.email = employee.getEmail();
+        dto.phoneNumber = employee.getPhoneNumber();
+        dto.zipcode = address.getZipcode();
+        dto.address1= address.getAddress1();
+        dto.address2 = address.getAddress2();
+
+        if(employeePortfolio!=null){
+            dto.introduction=employeePortfolio.getIntroduction();
+            dto.enrollmentCertificateUrl = employeePortfolio.getEnrollmentCertificateUrl();
+            dto.transcriptUrl = employeePortfolio.getTranscriptUrl();
+            dto.partTimeWorkPermitUrl=employeePortfolio.getPartTimeWorkPermitUrl();
+            dto.topic = employeePortfolio.getTopic();
+            dto.englishTestType = employeePortfolio.getEnglishTestType();
+            dto.englishTestScore = employeePortfolio.getEnglishTestScore();
+            dto.experiences=employeePortfolio.getExperiences();
+            dto.certifications=employeePortfolio.getCertifications();
+            dto.awards=employeePortfolio.getAwards();
+        }
+
+
+
+        dto.texts = resumeDTO.getTexts();
+        dto.files = resumeDTO.getFiles();
+
+        dto.portfolioPublic=resumeDTO.isPublic();
+
+        return dto;
+
+    }
+}

--- a/src/main/java/com/core/foreign/api/recruit/dto/PremiumResumeRequestDTO.java
+++ b/src/main/java/com/core/foreign/api/recruit/dto/PremiumResumeRequestDTO.java
@@ -1,5 +1,6 @@
 package com.core.foreign.api.recruit.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -12,6 +13,7 @@ public class PremiumResumeRequestDTO {
 
     private List<ResumePortfolioRequestDTO> resumePortfolios;
 
+    @JsonProperty("public")
     private boolean isPublic;
 
 

--- a/src/main/java/com/core/foreign/api/recruit/dto/internal/ResumeDTO.java
+++ b/src/main/java/com/core/foreign/api/recruit/dto/internal/ResumeDTO.java
@@ -1,0 +1,65 @@
+package com.core.foreign.api.recruit.dto.internal;
+
+import com.core.foreign.api.contract.entity.ContractStatus;
+import com.core.foreign.api.recruit.dto.ResumePortfolioDTO;
+import com.core.foreign.api.recruit.dto.ResumePortfolioFileResponseDTO;
+import com.core.foreign.api.recruit.dto.ResumePortfolioTextResponseDTO;
+import com.core.foreign.api.recruit.entity.ApplyMethod;
+import com.core.foreign.api.recruit.entity.EvaluationStatus;
+import com.core.foreign.api.recruit.entity.RecruitmentStatus;
+import com.core.foreign.api.recruit.entity.Resume;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ResumeDTO {
+    private Long resumeId;
+    private Long employeeId;
+    private Long recruitId;
+    private String messageToEmployer;
+    private ApplyMethod applyMethod;
+    private RecruitmentStatus recruitmentStatus;
+    private LocalDate approvedAt;
+    private EvaluationStatus isEmployeeEvaluatedByEmployer; // 고용인이 피고용인을 평가했는지 여부
+    private LocalDate employeeEvaluationDate; // 고용인이 피고용인을 평가한 날짜
+    private EvaluationStatus isEmployerEvaluatedByEmployee; // 피고용인이 고용인을 평가했는지 여부
+    private LocalDate employerEvaluationDate; // 피고용인이 고용인을 평가한 날짜
+    private boolean isPublic;  // 프리미엄 공고일 때만 유효함.
+    private Integer viewCount;  // 프리미엄 공고일 때만 유효함.
+    private ContractStatus contractStatus;
+    private LocalDate contractCompletionDate;
+    private List<ResumePortfolioTextResponseDTO> texts;
+    private List<ResumePortfolioFileResponseDTO> files;
+
+    public static ResumeDTO from(Resume resume, ResumePortfolioDTO resumePortfolioDTO){
+        ResumeDTO resumeDTO = new ResumeDTO();
+        resumeDTO.resumeId = resume.getId();
+        resumeDTO.employeeId = resume.getEmployee().getId();
+        resumeDTO.recruitId = resume.getRecruit().getId();
+        resumeDTO.messageToEmployer = resume.getMessageToEmployer();
+        resumeDTO.applyMethod = resume.getApplyMethod();
+        resumeDTO.recruitmentStatus = resume.getRecruitmentStatus();
+        resumeDTO.approvedAt = resume.getApprovedAt();
+        resumeDTO.isEmployeeEvaluatedByEmployer= resume.getIsEmployeeEvaluatedByEmployer();
+        resumeDTO.employeeEvaluationDate = resume.getEmployeeEvaluationDate();
+        resumeDTO.isEmployerEvaluatedByEmployee= resume.getIsEmployerEvaluatedByEmployee();
+        resumeDTO.employerEvaluationDate = resume.getEmployerEvaluationDate();
+        resumeDTO.isPublic = resume.isPublic();
+        resumeDTO.viewCount = resume.getViewCount();
+        resumeDTO.contractStatus = resume.getContractStatus();
+        resumeDTO.contractCompletionDate = resume.getContractCompletionDate();
+        resumeDTO.texts = resumePortfolioDTO.getTexts();
+        resumeDTO.files = resumePortfolioDTO.getFiles();
+
+        return resumeDTO;
+
+    }
+
+}
+
+

--- a/src/main/java/com/core/foreign/api/recruit/repository/ResumeRepository.java
+++ b/src/main/java/com/core/foreign/api/recruit/repository/ResumeRepository.java
@@ -25,7 +25,19 @@ public interface ResumeRepository extends JpaRepository<Resume, Long>, ResumeRep
             " join fetch r.employee" +
             " join fetch r.recruit" +
             " where r.id=:resumeId and r.isDeleted=false")
+    Optional<Resume>findResumeWithEmployeeAndRecruitForEmployer(@Param("resumeId")Long resumeId);
+
+    @Query("select r from Resume r" +
+            " join fetch r.employee" +
+            " join fetch r.recruit" +
+            " where r.id=:resumeId and r.isDeleted=false")
     Optional<Resume>findResumeWithEmployeeAndRecruit(@Param("resumeId")Long resumeId);
+
+    @Query("select r from Resume r" +
+            " join fetch r.employee employee" +
+            " join fetch r.recruit" +
+            " where r.id=:resumeId and r.isDeleted=false and employee.id=:employeeId")
+    Optional<Resume>findMyResumeWithEmployeeAndRecruit(@Param("employeeId")Long employeeId, @Param("resumeId")Long resumeId);
 
     @Query("select r from Resume r" +
             " join fetch r.employee employee" +

--- a/src/main/java/com/core/foreign/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/core/foreign/common/config/security/SecurityConfig.java
@@ -77,6 +77,8 @@ public class SecurityConfig {
                         .requestMatchers(
                                 HttpMethod.GET, "/api/v1/albareview/**", "/api/v1/albareview","/api/v1/albareview/comment","/api/v1/albareview/search"
                         ).permitAll() // 알바 후기 조회, 검색 관련 API
+                        .requestMatchers("/api/v1/portfolio/basics", "/api/v1/portfolio/basics/{employee-id}", "/api/v1/portfolio/applications", "/api/v1/portfolio/applications/{resume-id}")
+                        .permitAll()
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(exceptionHandling ->


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #162 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 포트폴리오 조회 시 로그인 유무에 따라 다르게 처리.
- 조회 시 공통된 부분이 많아 이전 코드 재활용했던 부분 분리 (ex) 마이페이지(피고용인) 이력서 조회, 마이페이지(고용인) 이력서 조회)
- 도메인 간 DTO 추가.


## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
- 비로그인 실제 지원 리스트 조회
![비로그인 실제 지원 리스트 조회](https://github.com/user-attachments/assets/a84c3872-07a3-4adc-a4ae-5ebcc4ac2c89)
- 비로그인 실제 지원 상세 조회
![비로그인 실제 지원 상세 조회](https://github.com/user-attachments/assets/efa35d75-e613-4f58-8c7d-6c047762b46e)
- 비로그인 포트폴리오 리스트 조회
![비로그인 포트폴리오 리스트 조회](https://github.com/user-attachments/assets/03a790ac-2303-4e58-8fa4-761999ee26e6)
- 비로그인 포트폴리오 상세 조회 성공
![비로그인 포트폴리오 상세 조회 성공](https://github.com/user-attachments/assets/08ee43d8-0cc5-47ae-ae73-311805f62c02)
- [지원자 이력서 보기 성공
![지원자 이력서 보기 성공](https://github.com/user-attachments/assets/3838f077-41ab-4fff-b55d-61d4be39fc24)
- 피고용인 내 이력서 조회 성공
![피고용인 내 이력서 조회 성공](https://github.com/user-attachments/assets/d9bc7f76-e063-4f1a-b203-ce6b517deae3)

