### PR TITLE
[FIX] 파일 업로드, 파일 업로드 계약서 등록 및 수정 그리고 피고용인 공고 지원 가능성 판단.

### DIFF
--- a/src/main/java/com/core/foreign/api/contract/controller/ContractController.java
+++ b/src/main/java/com/core/foreign/api/contract/controller/ContractController.java
@@ -5,6 +5,8 @@ import com.core.foreign.api.contract.dto.ContractPreviewResponseDTO;
 import com.core.foreign.api.contract.entity.ContractStatus;
 import com.core.foreign.api.contract.entity.ContractType;
 import com.core.foreign.api.contract.service.ContractService;
+import com.core.foreign.api.file.dto.FileUrlAndOriginalFileNameDTO;
+import com.core.foreign.api.file.dto.request.Urls;
 import com.core.foreign.api.member.entity.Role;
 import com.core.foreign.api.recruit.dto.PageResponseDTO;
 import com.core.foreign.common.SecurityMember;
@@ -16,11 +18,11 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @Tag(name = "Contract", description = "Contract 관련 API 입니다.")
 @RestController
@@ -80,13 +82,13 @@ public class ContractController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "업로드 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
     })
-    @PostMapping(value = "/{contract-id}/file", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ApiResponse<String>> uploadFileContract(@AuthenticationPrincipal SecurityMember securityMember,
+    @PostMapping(value = "/{contract-id}/file")
+    public ResponseEntity<ApiResponse<Void>> uploadFileContract(@AuthenticationPrincipal SecurityMember securityMember,
                                                                 @PathVariable("contract-id") Long contractMetadataId,
-                                                                @RequestPart(value = "contract", required = false) MultipartFile contract) {
-        String url = contractService.uploadFileContract(securityMember.getId(), contractMetadataId, contract);
+                                                                @RequestBody Urls urls) {
+        contractService.uploadFileContract(securityMember.getId(), contractMetadataId, urls.getUrls());
 
-        return ApiResponse.success(SuccessStatus.CONTRACT_UPLOAD_SUCCESS, url);
+        return ApiResponse.success_only(SuccessStatus.CONTRACT_UPLOAD_SUCCESS);
     }
 
     @Operation(summary = "실물 계약서 수정. API",
@@ -96,13 +98,13 @@ public class ContractController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "업로드 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
     })
-    @PatchMapping(value = "/{contract-id}/file", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ApiResponse<String>> modifyFileContract(@AuthenticationPrincipal SecurityMember securityMember,
-                                                                  @PathVariable("contract-id") Long contractMetadataId,
-                                                                  @RequestPart(value = "contract", required = false) MultipartFile contract) {
-        String url = contractService.uploadFileContract(securityMember.getId(), contractMetadataId, contract);
+    @PatchMapping(value = "/{contract-id}/file")
+    public ResponseEntity<ApiResponse<Void>> modifyFileContract(@AuthenticationPrincipal SecurityMember securityMember,
+                                                                @PathVariable("contract-id") Long contractMetadataId,
+                                                                @RequestBody Urls urls) {
+        contractService.uploadFileContract(securityMember.getId(), contractMetadataId, urls.getUrls());
 
-        return ApiResponse.success(SuccessStatus.CONTRACT_UPLOAD_SUCCESS, url);
+        return ApiResponse.success_only(SuccessStatus.CONTRACT_UPLOAD_SUCCESS);
     }
 
 
@@ -146,9 +148,9 @@ public class ContractController {
     })
     @GetMapping(value = "/test/not-completed")
     public ResponseEntity<ApiResponse<PageResponseDTO<AdminContractPreviewResponseDTO>>> test_getNotCompleteFileUploadContractMetadata(@AuthenticationPrincipal SecurityMember securityMember,
-                                                                  @RequestParam(value = "page", defaultValue = "0") Integer page,
-                                                                          @RequestParam("size")Integer size) {
-        size =size==null?3:size;
+                                                                                                                                       @RequestParam(value = "page", defaultValue = "0") Integer page,
+                                                                                                                                       @RequestParam("size") Integer size) {
+        size = size == null ? 3 : size;
 
         PageResponseDTO<AdminContractPreviewResponseDTO> response = contractService.getNotCompleteFileUploadContractMetadata(page, size);
 
@@ -163,10 +165,10 @@ public class ContractController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
     })
     @GetMapping(value = "/test/not-completed-one")
-    public ResponseEntity<ApiResponse<String>> test_getNotCompleteFileUploadContractMetadata(@AuthenticationPrincipal SecurityMember securityMember,
-                                                                                                                                       @RequestParam("contractId")Long contractMetadataId) {
+    public ResponseEntity<ApiResponse<List<FileUrlAndOriginalFileNameDTO>>> test_getNotCompleteFileUploadContractMetadata(@AuthenticationPrincipal SecurityMember securityMember,
+                                                                                                                          @RequestParam("contractId")Long contractMetadataId) {
 
-        String response = contractService.getNotFileUploadCompleteContractMetadata(contractMetadataId);
+        List<FileUrlAndOriginalFileNameDTO> response = contractService.getNotFileUploadCompleteContractMetadata(contractMetadataId);
 
         return ApiResponse.success(SuccessStatus.CONTRACT_UPLOAD_SUCCESS, response);
     }

--- a/src/main/java/com/core/foreign/api/contract/entity/ContractMetadata.java
+++ b/src/main/java/com/core/foreign/api/contract/entity/ContractMetadata.java
@@ -56,10 +56,7 @@ public class ContractMetadata {
 
 
     //  파일 업로드
-    public void uploadContract(String fileContractUrl) {
-        FileUploadContract fileUploadContract = (FileUploadContract) contract;
-
-        fileUploadContract.uploadContract(fileContractUrl);
+    public void setContractStatusPendingApproval() {
         this.employerContractStatus=ContractStatus.PENDING_APPROVAL;
         this.employeeContractStatus=ContractStatus.PENDING_APPROVAL;
     }

--- a/src/main/java/com/core/foreign/api/contract/entity/FileUploadContract.java
+++ b/src/main/java/com/core/foreign/api/contract/entity/FileUploadContract.java
@@ -23,5 +23,9 @@ public class FileUploadContract extends Contract{
         this.rejectionReason = rejectionReason;
     }
 
+    public void incrementVersion() {
+        this.curVersion++;
+    }
+
 
 }

--- a/src/main/java/com/core/foreign/api/contract/entity/FileUploadContract.java
+++ b/src/main/java/com/core/foreign/api/contract/entity/FileUploadContract.java
@@ -8,17 +8,12 @@ import lombok.NoArgsConstructor;
 @Entity
 @DiscriminatorValue("FILE")
 @Getter
-@NoArgsConstructor()
+@NoArgsConstructor
 public class FileUploadContract extends Contract{
-    private String fileContractUrl;
     private String rejectionReason;
     private Long curVersion=0L;
     private Long adminViewVersion;
 
-    public void uploadContract(String fileContractUrl) {
-        this.fileContractUrl = fileContractUrl;
-        curVersion++;
-    }
 
     public void synchronizeAdminViewVersion() {
         this.adminViewVersion = curVersion;

--- a/src/main/java/com/core/foreign/api/contract/entity/FileUploadContractUrl.java
+++ b/src/main/java/com/core/foreign/api/contract/entity/FileUploadContractUrl.java
@@ -1,0 +1,28 @@
+package com.core.foreign.api.contract.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class FileUploadContractUrl {
+    @Id @GeneratedValue(strategy = IDENTITY)
+    @Column(name="file_upload_contract_url")
+    private Long id;
+
+    private String url;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "file_upload_contract_id")
+    private FileUploadContract fileUploadContract;
+
+    public FileUploadContractUrl(String url, FileUploadContract fileUploadContract) {
+        this.url = url;
+        this.fileUploadContract = fileUploadContract;
+    }
+}

--- a/src/main/java/com/core/foreign/api/contract/repository/FileUploadContractUrlRepository.java
+++ b/src/main/java/com/core/foreign/api/contract/repository/FileUploadContractUrlRepository.java
@@ -1,0 +1,25 @@
+package com.core.foreign.api.contract.repository;
+
+import com.core.foreign.api.contract.entity.FileUploadContractUrl;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface FileUploadContractUrlRepository extends JpaRepository<FileUploadContractUrl, Long> {
+
+    @Query("select url from FileUploadContractUrl url" +
+            " where url.url in :urls")
+    List<FileUploadContractUrl> findByUrls(@Param("urls")List<String> urls);
+
+    @Query("select url from FileUploadContractUrl url" +
+            " where url.fileUploadContract.id=:fileUploadContractId")
+    List<FileUploadContractUrl> findByFileUploadContractId(@Param("fileUploadContractId") Long fileUploadContractId);
+
+
+    @Modifying
+    @Query("delete from FileUploadContractUrl url where url.id in :ids")
+    void deleteByIds(@Param("ids") List<Long> ids);
+}

--- a/src/main/java/com/core/foreign/api/contract/service/ContractUpdater.java
+++ b/src/main/java/com/core/foreign/api/contract/service/ContractUpdater.java
@@ -83,6 +83,9 @@ public class ContractUpdater {
 
         contractMetadata.setContractStatusPendingApproval();
 
+        // 버전 증가.
+        contract.incrementVersion();
+
     }
 
 

--- a/src/main/java/com/core/foreign/api/file/dto/FileUrlAndOriginalFileNameDTO.java
+++ b/src/main/java/com/core/foreign/api/file/dto/FileUrlAndOriginalFileNameDTO.java
@@ -1,0 +1,16 @@
+package com.core.foreign.api.file.dto;
+
+import com.core.foreign.api.file.entity.UploadFile;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FileUrlAndOriginalFileNameDTO {
+    private String fileUrl;
+    private String originalFileName;
+
+    public static FileUrlAndOriginalFileNameDTO of(UploadFile file){
+        return new FileUrlAndOriginalFileNameDTO(file.getFileUrl(), file.getOriginalFileName());
+    }
+}

--- a/src/main/java/com/core/foreign/api/file/dto/request/Urls.java
+++ b/src/main/java/com/core/foreign/api/file/dto/request/Urls.java
@@ -1,0 +1,10 @@
+package com.core.foreign.api.file.dto.request;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class Urls {
+    private List<String > urls;
+}

--- a/src/main/java/com/core/foreign/api/file/entity/UploadFile.java
+++ b/src/main/java/com/core/foreign/api/file/entity/UploadFile.java
@@ -1,0 +1,24 @@
+package com.core.foreign.api.file.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class UploadFile {
+    @Id @GeneratedValue(strategy = IDENTITY)
+    @Column(name="upload_file_id")
+    private Long id;
+
+    private String fileUrl;
+    private String originalFileName;
+
+    public UploadFile(String fileUrl, String originalFileName) {
+        this.fileUrl = fileUrl;
+        this.originalFileName = originalFileName;
+    }
+}

--- a/src/main/java/com/core/foreign/api/file/repository/UploadFileRepository.java
+++ b/src/main/java/com/core/foreign/api/file/repository/UploadFileRepository.java
@@ -1,0 +1,15 @@
+package com.core.foreign.api.file.repository;
+
+
+import com.core.foreign.api.file.entity.UploadFile;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface UploadFileRepository extends JpaRepository<UploadFile, Long> {
+    @Query("select file from UploadFile file" +
+            " where file.fileUrl in :fileUrls")
+    List<UploadFile> findByFileUrls(@Param("fileUrls") List<String> fileUrls);
+}

--- a/src/main/java/com/core/foreign/api/file/service/FileService.java
+++ b/src/main/java/com/core/foreign/api/file/service/FileService.java
@@ -2,6 +2,8 @@ package com.core.foreign.api.file.service;
 
 import com.core.foreign.api.aws.service.S3Service;
 import com.core.foreign.api.file.FileDirAndName;
+import com.core.foreign.api.file.entity.UploadFile;
+import com.core.foreign.api.file.repository.UploadFileRepository;
 import com.core.foreign.api.member.repository.MemberRepository;
 import com.core.foreign.common.exception.InternalServerException;
 import com.core.foreign.common.response.ErrorStatus;
@@ -18,13 +20,22 @@ import java.io.IOException;
 public class FileService {
     private final S3Service s3Service;
     private final MemberRepository memberRepository;
+    private final UploadFileRepository uploadFileRepository;
 
     public String uploadOnlyS3(MultipartFile file, FileDirAndName fileDirAndName) {
         String url = null;
+        String originalFilename=null;
         if (file != null && !file.isEmpty()) {
             try {
                 // S3에 업로드.
                 url = s3Service.uploadFile(file, fileDirAndName);
+
+                // DB 저장
+                 originalFilename = file.getOriginalFilename();
+
+                UploadFile uploadFile = new UploadFile(url, originalFilename);
+
+                uploadFileRepository.save(uploadFile);
 
 
             } catch (IOException e) {

--- a/src/main/java/com/core/foreign/api/member/controller/MemberController.java
+++ b/src/main/java/com/core/foreign/api/member/controller/MemberController.java
@@ -4,6 +4,7 @@ import com.core.foreign.api.business_field.BusinessField;
 import com.core.foreign.api.contract.dto.EmployeeCompletedContractResponseDTO;
 import com.core.foreign.api.contract.dto.EmployerCompletedContractResponseDTO;
 import com.core.foreign.api.contract.service.ContractService;
+import com.core.foreign.api.file.dto.FileUrlAndOriginalFileNameDTO;
 import com.core.foreign.api.file.service.FileService;
 import com.core.foreign.api.member.dto.*;
 import com.core.foreign.api.member.entity.EvaluationCategory;
@@ -805,9 +806,9 @@ public class MemberController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
     })
     @GetMapping(value = "/complete-file-upload-contract/{contract-id}")
-    public ResponseEntity<ApiResponse<String>> getCompletedFileUploadContract(@AuthenticationPrincipal SecurityMember securityMember,
+    public ResponseEntity<ApiResponse<List<FileUrlAndOriginalFileNameDTO>>> getCompletedFileUploadContract(@AuthenticationPrincipal SecurityMember securityMember,
                                                                               @PathVariable("contract-id") Long contractMetadataId) {
-        String response = contractService.getCompletedFileUploadContract(securityMember.getId(), contractMetadataId);
+        List<FileUrlAndOriginalFileNameDTO> response = contractService.getCompletedFileUploadContract(securityMember.getId(), contractMetadataId);
 
         return ApiResponse.success(SuccessStatus.COMPLETE_CONTRACT_VIEW_SUCCESS, response);
     }

--- a/src/main/java/com/core/foreign/api/member/service/EmployeePortfolioService.java
+++ b/src/main/java/com/core/foreign/api/member/service/EmployeePortfolioService.java
@@ -10,8 +10,6 @@ import com.core.foreign.api.member.entity.EmployeePortfolioBusinessFieldInfo;
 import com.core.foreign.api.member.repository.EmployeePortfolioBusinessFieldInfoRepository;
 import com.core.foreign.api.member.repository.EmployeePortfolioRepository;
 import com.core.foreign.api.member.repository.MemberRepository;
-import com.core.foreign.common.exception.BadRequestException;
-import com.core.foreign.common.response.ErrorStatus;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -60,11 +58,10 @@ public class EmployeePortfolioService {
                     Employee employee = portfolio.getEmployee();
                     return EmployeePortfolioDTO.from(portfolio, employee.isPortfolioPublic());
                 })
-                .orElseThrow(()->{
-                        log.warn("[getEmployeePortfolio][포트폴리오 없음.][employerId= {}]", employeeId);
-                            return new BadRequestException(ErrorStatus.PORTFOLIO_NOT_FOUND_EXCEPTION.getMessage());
-                        }
-                );
+                .orElseGet(()->{
+                    log.warn("[getEmployeePortfolio][포트폴리오 없음.][employeeId= {}]", employeeId);
+                    return EmployeePortfolioDTO.emptyPortfolio();
+                });
 
         return response;
     }

--- a/src/main/java/com/core/foreign/api/recruit/controller/RecruitController.java
+++ b/src/main/java/com/core/foreign/api/recruit/controller/RecruitController.java
@@ -1077,5 +1077,17 @@ public class RecruitController {
         return ApiResponse.success(SuccessStatus.SEARCH_RECRUIT_SUCESS, response);
     }
 
+    @Operation(summary = "피고용인 공고 지원 가능한지 판단. API",
+            description = "피고용인 공고 지원 가능한지 판단. API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "판단 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다.")
+    })
+    @PostMapping("/{recruit-id}/validate-application")
+    public ResponseEntity<ApiResponse<Boolean>> isEmployeeEligibleForRecruitment(@AuthenticationPrincipal SecurityMember securityMember,
+                                                                                 @PathVariable("recruit-id") Long recruitId) {
 
+        boolean response = recruitService.isEmployeeEligibleForRecruitment(securityMember.getId(), recruitId);
+        return ApiResponse.success(SuccessStatus.EMPLOYEE_ELIGIBLE_FOR_APPLICATION, response);
+    }
 }

--- a/src/main/java/com/core/foreign/api/recruit/dto/ResumePortfolioFileResponseDTO.java
+++ b/src/main/java/com/core/foreign/api/recruit/dto/ResumePortfolioFileResponseDTO.java
@@ -1,19 +1,18 @@
 package com.core.foreign.api.recruit.dto;
 
-import com.core.foreign.api.recruit.entity.PortfolioType;
+import com.core.foreign.api.file.dto.FileUrlAndOriginalFileNameDTO;
 import lombok.Getter;
 
 import java.util.List;
 
+
 @Getter
 public class ResumePortfolioFileResponseDTO {
-    private PortfolioType portfolioType;
     private String title;
-    private List<String> urls;
+    private List<FileUrlAndOriginalFileNameDTO> fileUrlAndOriginalFileNameDTOS;
 
-    public ResumePortfolioFileResponseDTO(PortfolioType portfolioType, String title, List<String> urls) {
-        this.portfolioType = portfolioType;
+    public ResumePortfolioFileResponseDTO(String title, List<FileUrlAndOriginalFileNameDTO> fileUrlAndOriginalFileNameDTOS) {
         this.title = title;
-        this.urls = urls;
+        this.fileUrlAndOriginalFileNameDTOS = fileUrlAndOriginalFileNameDTOS;
     }
 }

--- a/src/main/java/com/core/foreign/api/recruit/dto/ResumePortfolioTextResponseDTO.java
+++ b/src/main/java/com/core/foreign/api/recruit/dto/ResumePortfolioTextResponseDTO.java
@@ -1,19 +1,15 @@
 package com.core.foreign.api.recruit.dto;
 
-import com.core.foreign.api.recruit.entity.PortfolioType;
 import com.core.foreign.api.recruit.entity.ResumePortfolio;
 import lombok.Getter;
 
 @Getter
 public class ResumePortfolioTextResponseDTO {
-    private PortfolioType PortfolioType;
     private String title;
     private String content;
 
-
     public static ResumePortfolioTextResponseDTO from(ResumePortfolio resumePortfolio){
         ResumePortfolioTextResponseDTO dto = new ResumePortfolioTextResponseDTO();
-        dto.PortfolioType=resumePortfolio.getPortfolioType();
         dto.title=resumePortfolio.getTitle();
         dto.content=resumePortfolio.getContent();
         return dto;

--- a/src/main/java/com/core/foreign/api/recruit/service/RecruitService.java
+++ b/src/main/java/com/core/foreign/api/recruit/service/RecruitService.java
@@ -4,9 +4,8 @@ import com.core.foreign.api.aws.service.S3Service;
 import com.core.foreign.api.business_field.BusinessField;
 import com.core.foreign.api.member.dto.EmployerEvaluationCountDTO;
 import com.core.foreign.api.member.dto.EmployerReliabilityDTO;
-import com.core.foreign.api.member.entity.Address;
-import com.core.foreign.api.member.entity.Employer;
-import com.core.foreign.api.member.entity.Member;
+import com.core.foreign.api.member.entity.*;
+import com.core.foreign.api.member.repository.EmployeePortfolioRepository;
 import com.core.foreign.api.member.repository.EmployerRepository;
 import com.core.foreign.api.member.repository.MemberRepository;
 import com.core.foreign.api.member.service.EvaluationReader;
@@ -21,7 +20,10 @@ import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.Predicate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.*;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,13 +32,12 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.util.*;
 
-import static com.core.foreign.common.response.ErrorStatus.RECRUIT_NOT_FOUND_EXCEPTION;
+import static com.core.foreign.common.response.ErrorStatus.*;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class RecruitService {
-
     private final RecruitRepository recruitRepository;
     private final MemberRepository memberRepository;
     private final PremiumManageRepository premiumManageRepository;
@@ -46,6 +47,7 @@ public class RecruitService {
     private final EvaluationReader evaluationReader;
     private final PortfolioRepository portfolioRepository;
     private final EmployerRepository employerRepository;
+    private final EmployeePortfolioRepository employeePortfolioRepository;
 
     // 일반 공고 등록
     @Transactional
@@ -974,4 +976,52 @@ public class RecruitService {
         return PageResponseDTO.of(dtoPage);
     }
 
+
+    public boolean isEmployeeEligibleForRecruitment(Long employeeId, Long recruitId) {
+
+        Member member = memberRepository.findById(employeeId).get();
+        if (member instanceof Employer) {
+            log.warn("고용인이 공고 지원 신청. memberId= {}", employeeId);
+            throw new BadRequestException(EMPLOYER_CANNOT_APPLY_EXCEPTION.getMessage());
+        }
+
+        Employee employee = (Employee) member;
+
+        Recruit recruit = recruitRepository.findById(recruitId)
+                .orElseThrow(() -> {
+                            log.warn("[isEmployeeEligibleForRecruitment][공고 없음.][recruitId= {}]", recruitId);
+                            return new BadRequestException(RECRUIT_NOT_FOUND_EXCEPTION.getMessage());
+                        }
+                );
+
+        Optional<Resume> findResume = resumeRepository.findByEmployeeIdAndRecruitId(employeeId, recruit.getId());
+
+        // 중복 지원 체크
+
+        if (findResume.isPresent()) {
+            log.warn("[isEmployeeEligibleForRecruitment][중복 지원은 불가합니다.][resumeId= {}]", findResume.get().getId());
+            throw new BadRequestException(DUPLICATE_APPLICATION_NOT_ALLOWED_EXCEPTION.getMessage());
+
+        }
+
+        // 포트폴리오 체크
+        if (recruit.getRecruitType().equals(RecruitType.PREMIUM)) {
+            EmployeePortfolio employeePortfolio = employeePortfolioRepository.findEmployeePortfolioByEmployeeId(employee.getId())
+                    .orElseThrow(() -> {
+                        log.warn("[isEmployeeEligibleForRecruitment][포트폴리오 없음][employeeId= {}]", employeeId);
+                        return new BadRequestException(PORTFOLIO_NOT_FOUND_EXCEPTION.getMessage());
+                    });
+
+            if (employeePortfolio.getIntroduction() == null || employeePortfolio.getIntroduction().isEmpty() ||
+                    employeePortfolio.getEnrollmentCertificateUrl() == null || employeePortfolio.getEnrollmentCertificateUrl().isEmpty() ||
+                    employeePortfolio.getTranscriptUrl() == null || employeePortfolio.getTranscriptUrl().isEmpty() ||
+                    employeePortfolio.getPartTimeWorkPermitUrl() == null || employeePortfolio.getPartTimeWorkPermitUrl().isEmpty()
+            ) {
+                log.warn("[isEmployeeEligibleForRecruitment][필수 항수 없음][employeeId= {}]", employeeId);
+                throw new BadRequestException(MISSING_REQUIRED_SPEC_OR_EXPERIENCE_EXCEPTION.getMessage());
+            }
+        }
+
+        return true;
+    }
 }

--- a/src/main/java/com/core/foreign/api/recruit/service/RecruitService.java
+++ b/src/main/java/com/core/foreign/api/recruit/service/RecruitService.java
@@ -1009,7 +1009,7 @@ public class RecruitService {
             EmployeePortfolio employeePortfolio = employeePortfolioRepository.findEmployeePortfolioByEmployeeId(employee.getId())
                     .orElseThrow(() -> {
                         log.warn("[isEmployeeEligibleForRecruitment][포트폴리오 없음][employeeId= {}]", employeeId);
-                        return new BadRequestException(PORTFOLIO_NOT_FOUND_EXCEPTION.getMessage());
+                        return new NotFoundException(PORTFOLIO_NOT_FOUND_EXCEPTION.getMessage());
                     });
 
             if (employeePortfolio.getIntroduction() == null || employeePortfolio.getIntroduction().isEmpty() ||

--- a/src/main/java/com/core/foreign/api/recruit/service/ResumeReader.java
+++ b/src/main/java/com/core/foreign/api/recruit/service/ResumeReader.java
@@ -1,6 +1,9 @@
 package com.core.foreign.api.recruit.service;
 
 import com.core.foreign.api.contract.entity.ContractStatus;
+import com.core.foreign.api.file.dto.FileUrlAndOriginalFileNameDTO;
+import com.core.foreign.api.file.entity.UploadFile;
+import com.core.foreign.api.file.repository.UploadFileRepository;
 import com.core.foreign.api.member.dto.TagResponseDTO;
 import com.core.foreign.api.recruit.dto.*;
 import com.core.foreign.api.recruit.dto.internal.ResumeDTO;
@@ -31,6 +34,7 @@ public class ResumeReader {
     private final ResumeRepository resumeRepository;
     private final ResumePortfolioRepository resumePortfolioRepository;
     private final PortfolioRepository portfolioRepository;
+    private final UploadFileRepository uploadFileRepository;
 
     public ResumeDTO getResumeForEmployer(Long resumeId){
         Resume resume = resumeRepository.findResumeWithEmployeeAndRecruitForEmployer(resumeId)
@@ -139,7 +143,16 @@ public class ResumeReader {
                 List<String> urls = fileMap.get(recruitPortfolioId);
                 Portfolio portfolio = map.get(recruitPortfolioId);
 
-                files.add(new ResumePortfolioFileResponseDTO(PortfolioType.FILE_UPLOAD, portfolio.getTitle(), urls));
+                List<UploadFile> byFileUrls = uploadFileRepository.findByFileUrls(urls);
+
+                List<FileUrlAndOriginalFileNameDTO> fileUrlAndOriginalFileNameDTOS =new ArrayList<>();
+
+                for (UploadFile byFileUrl : byFileUrls) {
+                    FileUrlAndOriginalFileNameDTO fileUrlAndOriginalFileNameDTO = new FileUrlAndOriginalFileNameDTO(byFileUrl.getFileUrl(), byFileUrl.getOriginalFileName());
+                    fileUrlAndOriginalFileNameDTOS.add(fileUrlAndOriginalFileNameDTO);
+                }
+
+                files.add(new ResumePortfolioFileResponseDTO(portfolio.getTitle(), fileUrlAndOriginalFileNameDTOS));
             }
         }
 

--- a/src/main/java/com/core/foreign/api/recruit/service/ResumeService.java
+++ b/src/main/java/com/core/foreign/api/recruit/service/ResumeService.java
@@ -4,7 +4,10 @@ import com.core.foreign.api.contract.entity.ContractStatus;
 import com.core.foreign.api.contract.service.ContractCreator;
 import com.core.foreign.api.member.dto.EmployeePortfolioDTO;
 import com.core.foreign.api.member.dto.TagResponseDTO;
-import com.core.foreign.api.member.entity.*;
+import com.core.foreign.api.member.entity.Employee;
+import com.core.foreign.api.member.entity.EmployeePortfolio;
+import com.core.foreign.api.member.entity.Employer;
+import com.core.foreign.api.member.entity.Member;
 import com.core.foreign.api.member.repository.EmployeePortfolioRepository;
 import com.core.foreign.api.member.repository.EmployeeRepository;
 import com.core.foreign.api.member.repository.MemberRepository;
@@ -241,19 +244,21 @@ public class ResumeService {
 
         }
 
-        EmployeePortfolio employeePortfolio = employeePortfolioRepository.findEmployeePortfolioByEmployeeId(employee.getId())
-                .orElseThrow(() -> {
-                    log.warn("[doApplyResume][포트폴리오 없음][employeeId= {}]", employeeId);
-                    return new BadRequestException(PORTFOLIO_NOT_FOUND_EXCEPTION.getMessage());
-                });
+        if(recruit.getRecruitType().equals(RecruitType.PREMIUM)){
+            EmployeePortfolio employeePortfolio = employeePortfolioRepository.findEmployeePortfolioByEmployeeId(employee.getId())
+                    .orElseThrow(() -> {
+                        log.warn("[doApplyResume][포트폴리오 없음][employeeId= {}]", employeeId);
+                        return new BadRequestException(PORTFOLIO_NOT_FOUND_EXCEPTION.getMessage());
+                    });
 
-        if(employeePortfolio.getIntroduction()==null||employeePortfolio.getIntroduction().isEmpty()||
-                employeePortfolio.getEnrollmentCertificateUrl()==null||employeePortfolio.getEnrollmentCertificateUrl().isEmpty()||
-                employeePortfolio.getTranscriptUrl()==null||employeePortfolio.getTranscriptUrl().isEmpty()||
-                employeePortfolio.getPartTimeWorkPermitUrl()==null||employeePortfolio.getPartTimeWorkPermitUrl().isEmpty()
-        ){
-            log.warn("[doApplyResume][필수 항수 없음][employeeId= {}]", employeeId);
-            throw new BadRequestException(MISSING_REQUIRED_SPEC_OR_EXPERIENCE_EXCEPTION.getMessage());
+            if(employeePortfolio.getIntroduction()==null||employeePortfolio.getIntroduction().isEmpty()||
+                    employeePortfolio.getEnrollmentCertificateUrl()==null||employeePortfolio.getEnrollmentCertificateUrl().isEmpty()||
+                    employeePortfolio.getTranscriptUrl()==null||employeePortfolio.getTranscriptUrl().isEmpty()||
+                    employeePortfolio.getPartTimeWorkPermitUrl()==null||employeePortfolio.getPartTimeWorkPermitUrl().isEmpty()
+            ){
+                log.warn("[doApplyResume][필수 항수 없음][employeeId= {}]", employeeId);
+                throw new BadRequestException(MISSING_REQUIRED_SPEC_OR_EXPERIENCE_EXCEPTION.getMessage());
+            }
         }
 
         Resume build = Resume.builder()

--- a/src/main/java/com/core/foreign/api/recruit/service/ResumeService.java
+++ b/src/main/java/com/core/foreign/api/recruit/service/ResumeService.java
@@ -19,6 +19,7 @@ import com.core.foreign.api.recruit.repository.RecruitRepository;
 import com.core.foreign.api.recruit.repository.ResumePortfolioRepository;
 import com.core.foreign.api.recruit.repository.ResumeRepository;
 import com.core.foreign.common.exception.BadRequestException;
+import com.core.foreign.common.exception.NotFoundException;
 import com.core.foreign.common.response.ErrorStatus;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -248,7 +249,7 @@ public class ResumeService {
             EmployeePortfolio employeePortfolio = employeePortfolioRepository.findEmployeePortfolioByEmployeeId(employee.getId())
                     .orElseThrow(() -> {
                         log.warn("[doApplyResume][포트폴리오 없음][employeeId= {}]", employeeId);
-                        return new BadRequestException(PORTFOLIO_NOT_FOUND_EXCEPTION.getMessage());
+                        return new NotFoundException(PORTFOLIO_NOT_FOUND_EXCEPTION.getMessage());
                     });
 
             if(employeePortfolio.getIntroduction()==null||employeePortfolio.getIntroduction().isEmpty()||

--- a/src/main/java/com/core/foreign/common/response/ErrorStatus.java
+++ b/src/main/java/com/core/foreign/common/response/ErrorStatus.java
@@ -74,6 +74,9 @@ public enum ErrorStatus {
     INVALID_CONTRACT_OWNER_EXCEPTION(HttpStatus.BAD_REQUEST, "계약서 소유자가 아닙니다."),
     INVALID_RESUME_OWNER_EXCEPTION(HttpStatus.BAD_REQUEST, "이력서 소유자가 아닙니다."),
     MISSING_REQUIRED_SPEC_OR_EXPERIENCE_EXCEPTION(HttpStatus.BAD_REQUEST, "필수 스펙 및 경력이 없습니다."),
+    CONTRACT_ALREADY_COMPLETED_EXCEPTION(HttpStatus.BAD_REQUEST, "완료된 계약서는 수정할 수 없습니다."),
+    CONTRACT_VERSION_MISMATCH_EXCEPTION(HttpStatus.BAD_REQUEST, "계약서가 변경되었습니다. 다시 확인하세요."),
+    CONTRACT_REVIEW_REQUIRED_EXCEPTION(HttpStatus.BAD_REQUEST, "먼저 계약서를 확인하세요."),
 
 
     /**
@@ -103,9 +106,7 @@ public enum ErrorStatus {
     COMMENT_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND,"부모 댓글을 찾을 수 없습니다."),
     PORTFOLIO_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "포트폴리오(스펙 및 경력)를 찾을 수 없습니다."),
     CONTRACT_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "계약서를 찾을 수 없습니다."),
-    CONTRACT_ALREADY_COMPLETED_EXCEPTION(HttpStatus.BAD_REQUEST, "완료된 계약서는 수정할 수 없습니다."),
-    CONTRACT_VERSION_MISMATCH_EXCEPTION(HttpStatus.BAD_REQUEST, "계약서가 변경되었습니다. 다시 확인하세요."),
-    CONTRACT_REVIEW_REQUIRED_EXCEPTION(HttpStatus.BAD_REQUEST, "먼저 계약서를 확인하세요."),
+
 
 
 

--- a/src/main/java/com/core/foreign/common/response/SuccessStatus.java
+++ b/src/main/java/com/core/foreign/common/response/SuccessStatus.java
@@ -77,6 +77,7 @@ public enum SuccessStatus {
     SEARCH_RECRUIT_SUCESS(HttpStatus.OK,"공고 검색 성공"),
     RESUME_VISIBILITY_UPDATE_SUCCESS(HttpStatus.OK, "이력서 공개 상태 변경 성공"),
     MEMBER_WITHDRAW_SUCCESS(HttpStatus.OK, "회원 탈퇴 성공"),
+    EMPLOYEE_ELIGIBLE_FOR_APPLICATION(HttpStatus.OK, "공고 지원이 가능한 피고용인입니다."),
 
 
     /**


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #179 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 파일 업로드 시 이미지가 아닌 첨부 파일(pdf 등)의 원본 파일 이름을 유지하고, 이를 저장하는 로직과 테이블을 추가해야 합니다. 
- 계약서 업로드 기능을 수정하여 하나의 계약서에서 여러 개의 파일을 업로드할 수 있도록 합니다.
- 공고 지원 시 중복 지원 및 프리미엄 공고에 대한 포트폴리오 관련 처리를 판단하는 로직을 구현합니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
- 중복 지원 불가
![중복 지원 불가](https://github.com/user-attachments/assets/a2e6b3dc-d451-4ae1-a4b2-ee01f6a19ab9)
- 포트폴리오 필수 항목 없어 지원 불가
![필수항목 없음](https://github.com/user-attachments/assets/b45d3966-319f-4e74-a455-0945bc358abc)
- 포트폴리오 없어서 지원 불가
![포트폴리오 없음](https://github.com/user-attachments/assets/b82b3cef-0e9a-463e-9398-657b6b6a4250)
- 파일 계약서 여러 개 수정 성공
![파일 계약서 여러 개 수정 성공](https://github.com/user-attachments/assets/f4bf7732-4332-4973-bfff-299400d9cc5c)
- 파일 계약서 여러 개 조회 성공
![파일 계약서 여러 개 조회 성공](https://github.com/user-attachments/assets/a42f063a-f756-48c6-92fc-e3821f0e5940)
