### PR TITLE
[FIX] 공고 지원 시 지원 방법 예외 처리 추가.

### DIFF
--- a/src/main/java/com/core/foreign/api/recruit/controller/RecruitController.java
+++ b/src/main/java/com/core/foreign/api/recruit/controller/RecruitController.java
@@ -997,13 +997,15 @@ public class RecruitController {
     @Operation(summary = "피고용인 공고 지원 가능한지 판단. API (용범)",
             description = "피고용인 공고 지원 가능한지 판단. API" +
                     "<p>" +
-                    "200: 지원 가능<br>" +
+                    "응답 코드)<br>" +
+                    "200: 공고 지원이 가능한 피고용인입니다.<br>" +
                     "그 외: 지원 불가<br>" +
-                    "400: 고용인이 공고 지원, 중복 지원, 스펙 및 경럭 필수 항목 없음<br>" +
-                    "404: 공고 없음, 스펙 및 경력 미작성")
+                    "400: 고용인은 공고에 지원할 수 없습니다, 필수 스펙 및 경력이 없습니다.<br>" +
+                    "404: 해당 공고를 찾을 수 없습니다, 포트폴리오(스펙 및 경력)를 찾을 수 없습니다.")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "판단 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다.")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "공고 지원이 가능한 피고용인입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "고용인은 공고에 지원할 수 없습니다, 필수 스펙 및 경력이 없습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 공고를 찾을 수 없습니다, 포트폴리오(스펙 및 경력)를 찾을 수 없습니다.")
     })
     @PostMapping("/{recruit-id}/validate-application")
     public ResponseEntity<ApiResponse<Void>> isEmployeeEligibleForRecruitment(@AuthenticationPrincipal SecurityMember securityMember,

--- a/src/main/java/com/core/foreign/api/recruit/controller/RecruitController.java
+++ b/src/main/java/com/core/foreign/api/recruit/controller/RecruitController.java
@@ -995,16 +995,19 @@ public class RecruitController {
     }
 
     @Operation(summary = "피고용인 공고 지원 가능한지 판단. API (용범)",
-            description = "피고용인 공고 지원 가능한지 판단. API")
+            description = "피고용인 공고 지원 가능한지 판단. API" +
+                    "<p>" +
+                    "200: 지원 가능" +
+                    "그 외: 지원 불가")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "판단 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다.")
     })
     @PostMapping("/{recruit-id}/validate-application")
-    public ResponseEntity<ApiResponse<Boolean>> isEmployeeEligibleForRecruitment(@AuthenticationPrincipal SecurityMember securityMember,
-                                                                                 @PathVariable("recruit-id") Long recruitId) {
+    public ResponseEntity<ApiResponse<Void>> isEmployeeEligibleForRecruitment(@AuthenticationPrincipal SecurityMember securityMember,
+                                                                              @PathVariable("recruit-id") Long recruitId) {
 
-        boolean response = recruitService.isEmployeeEligibleForRecruitment(securityMember.getId(), recruitId);
-        return ApiResponse.success(SuccessStatus.EMPLOYEE_ELIGIBLE_FOR_APPLICATION, response);
+        recruitService.isEmployeeEligibleForRecruitment(securityMember.getId(), recruitId);
+        return ApiResponse.success_only(SuccessStatus.EMPLOYEE_ELIGIBLE_FOR_APPLICATION);
     }
 }

--- a/src/main/java/com/core/foreign/api/recruit/controller/RecruitController.java
+++ b/src/main/java/com/core/foreign/api/recruit/controller/RecruitController.java
@@ -997,8 +997,10 @@ public class RecruitController {
     @Operation(summary = "피고용인 공고 지원 가능한지 판단. API (용범)",
             description = "피고용인 공고 지원 가능한지 판단. API" +
                     "<p>" +
-                    "200: 지원 가능" +
-                    "그 외: 지원 불가")
+                    "200: 지원 가능<br>" +
+                    "그 외: 지원 불가<br>" +
+                    "400: 고용인이 공고 지원, 중복 지원, 스펙 및 경럭 필수 항목 없음<br>" +
+                    "404: 공고 없음, 스펙 및 경력 미작성")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "판단 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다.")

--- a/src/main/java/com/core/foreign/api/recruit/repository/RecruitRepository.java
+++ b/src/main/java/com/core/foreign/api/recruit/repository/RecruitRepository.java
@@ -68,6 +68,11 @@ public interface RecruitRepository
     @Query("select pr from PremiumRecruit pr where pr.id = :id and pr.recruitPublishStatus = :status")
     Optional<PremiumRecruit> findPremiumDraftById(Long id, RecruitPublishStatus status);
 
+    @Query("select r from Recruit r" +
+            " join fetch r.applicationMethods" +
+            " where r.id=:recruitId")
+    Optional<Recruit> findByRecruitIdWithApplicationMethods(@Param("recruitId")Long recruitId);
+
     default Optional<PremiumRecruit> findPremiumDraftById(Long id) {
         return findPremiumDraftById(id, RecruitPublishStatus.DRAFT);
     }

--- a/src/main/java/com/core/foreign/api/recruit/service/RecruitService.java
+++ b/src/main/java/com/core/foreign/api/recruit/service/RecruitService.java
@@ -979,7 +979,7 @@ public class RecruitService {
     }
 
 
-    public boolean isEmployeeEligibleForRecruitment(Long employeeId, Long recruitId) {
+    public void isEmployeeEligibleForRecruitment(Long employeeId, Long recruitId) {
 
         Member member = memberRepository.findById(employeeId).get();
         if (member instanceof Employer) {
@@ -1023,7 +1023,5 @@ public class RecruitService {
                 throw new BadRequestException(MISSING_REQUIRED_SPEC_OR_EXPERIENCE_EXCEPTION.getMessage());
             }
         }
-
-        return true;
     }
 }

--- a/src/main/java/com/core/foreign/api/recruit/service/ResumeService.java
+++ b/src/main/java/com/core/foreign/api/recruit/service/ResumeService.java
@@ -47,7 +47,20 @@ public class ResumeService {
 
     @Transactional
     public Long applyResume(Long employeeId, Long recruitId, GeneralResumeRequestDTO dto) {
-        Recruit recruit = recruitRepository.findById(recruitId).orElseThrow(() -> new NotFoundException(RECRUIT_NOT_FOUND_EXCEPTION.getMessage()));
+        Recruit recruit = recruitRepository.findByRecruitIdWithApplicationMethods(recruitId)
+                .orElseThrow(()->{
+                    log.warn("[applyResume][공고 없음.][recruitId= {}]", recruitId);
+                    return new NotFoundException(ErrorStatus.RECRUIT_NOT_FOUND_EXCEPTION.getMessage());
+                });
+
+        Set<ApplyMethod> applicationMethods = recruit.getApplicationMethods();
+        ApplyMethod applyMethod = dto.getApplyMethod();
+
+        if(!applicationMethods.contains(applyMethod)){
+            log.warn("[applyResume][지원 방법 틀림.][applicationMethods= {}, requestApplyMethod= {}]", applicationMethods, dto.getApplyMethod());
+            throw new BadRequestException(ErrorStatus.INVALID_APPLY_METHOD_EXCEPTION.getMessage());
+        }
+
 
         if(recruit.getRecruitType()!=RecruitType.GENERAL) {
             throw  new BadRequestException(INVALID_RECRUIT_TYPE_EXCEPTION.getMessage());

--- a/src/main/java/com/core/foreign/common/response/ErrorStatus.java
+++ b/src/main/java/com/core/foreign/common/response/ErrorStatus.java
@@ -77,6 +77,8 @@ public enum ErrorStatus {
     CONTRACT_ALREADY_COMPLETED_EXCEPTION(HttpStatus.BAD_REQUEST, "완료된 계약서는 수정할 수 없습니다."),
     CONTRACT_VERSION_MISMATCH_EXCEPTION(HttpStatus.BAD_REQUEST, "계약서가 변경되었습니다. 다시 확인하세요."),
     CONTRACT_REVIEW_REQUIRED_EXCEPTION(HttpStatus.BAD_REQUEST, "먼저 계약서를 확인하세요."),
+    INVALID_APPLY_METHOD_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 지원 방법입니다. 올바른 방법으로 다시 시도하세요."),
+
 
 
     /**


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #188 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 공고 지원 시 정해진 방법으로만 지원 가능.
- 피고용인의 공고 지원 유무 판단 시 True 반환 제거.


## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
- true 응답 제거
![공고 지원 가능 ](https://github.com/user-attachments/assets/d2be17ce-0f50-499a-830f-d4d88b1a3178)
- 공고 지원 방법 틀림
![지원 방법 틀림](https://github.com/user-attachments/assets/51a03e8d-d658-4e4f-b235-8b2908b4b96c)
- 올바른 방법으로 지원 성공
![지원 성공](https://github.com/user-attachments/assets/0ada30f8-5cf9-4172-8a5f-365ab8a9f57e)

